### PR TITLE
Set anonymous functions display name using file name

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const semver = require('semver')
 const console = require('console')
 
-const DISPLAY_NAME_SYMBOL = Symbol.for('fastify-plugin.display-name')
+const DISPLAY_NAME_SYMBOL = Symbol.for('fastify.display-name')
 const fpStackTracePattern = new RegExp('at\\s{1}plugin\\s{1}.*\\n\\s*(.*)')
 const fileNamePattern = new RegExp('\\/(\\w*)\\.js')
 
@@ -68,4 +68,3 @@ function checkVersion (version) {
 }
 
 module.exports = plugin
-module.exports.DISPLAY_NAME_SYMBOL = DISPLAY_NAME_SYMBOL

--- a/index.js
+++ b/index.js
@@ -3,7 +3,9 @@
 const semver = require('semver')
 const console = require('console')
 
-const DISPLAY_NAME_SYMBOL = Symbol.for('display-name')
+const DISPLAY_NAME_SYMBOL = Symbol.for('fastify-plugin.display-name')
+const fpStackTracePattern = new RegExp('at\\s{1}plugin\\s{1}.*\\n\\s*(.*)')
+const fileNamePattern = new RegExp('\\/(\\w*)\\.js')
 
 function plugin (fn, options) {
   if (typeof fn !== 'function') {
@@ -38,14 +40,12 @@ function plugin (fn, options) {
 function checkName (fn) {
   if (fn.name.length > 0) return fn.name
 
-  const r1 = new RegExp('at\\s{1}plugin\\s{1}.*\\n\\s*(.*)')
-  const r2 = new RegExp('\\/(\\w*)\\.js')
   try {
     throw new Error('anonymous function')
   } catch (e) {
     const stack = e.stack
-    let m = stack.match(r1)
-    m = m[1].match(r2)[1]
+    let m = stack.match(fpStackTracePattern)
+    m = m[1].match(fileNamePattern)[1]
     return m
   }
 }

--- a/index.js
+++ b/index.js
@@ -3,10 +3,14 @@
 const semver = require('semver')
 const console = require('console')
 
+const DISPLAY_NAME_SYMBOL = Symbol.for('display-name')
+
 function plugin (fn, options) {
   if (typeof fn !== 'function') {
     throw new TypeError(`fastify-plugin expects a function, instead got a '${typeof fn}'`)
   }
+
+  fn[DISPLAY_NAME_SYMBOL] = checkName(fn)
 
   fn[Symbol.for('skip-override')] = true
 
@@ -31,6 +35,21 @@ function plugin (fn, options) {
   return fn
 }
 
+function checkName (fn) {
+  if (fn.name.length > 0) return fn.name
+
+  const r1 = new RegExp('at\\s{1}plugin\\s{1}.*\\n\\s*(.*)')
+  const r2 = new RegExp('\\/(\\w*)\\.js')
+  try {
+    throw new Error('anonymous function')
+  } catch (e) {
+    const stack = e.stack
+    let m = stack.match(r1)
+    m = m[1].match(r2)[1]
+    return m
+  }
+}
+
 function checkVersion (version) {
   if (typeof version !== 'string') {
     throw new TypeError(`fastify-plugin expects a version string, instead got '${typeof version}'`)
@@ -49,3 +68,4 @@ function checkVersion (version) {
 }
 
 module.exports = plugin
+module.exports.DISPLAY_NAME_SYMBOL = DISPLAY_NAME_SYMBOL

--- a/test.js
+++ b/test.js
@@ -178,5 +178,5 @@ test('should set anonymous function name to file it was called from', t => {
     next()
   })
 
-  t.is(fn[fp.DISPLAY_NAME_SYMBOL], 'test')
+  t.is(fn[Symbol('fastify.display-name')], 'test')
 })

--- a/test.js
+++ b/test.js
@@ -170,3 +170,13 @@ test('should throw if the fastify version does not satisfies the plugin requeste
     t.is(e.message, `fastify-plugin - expected '1000.1000.1000' fastify version, '${v}' is installed`)
   }
 })
+
+test('should set anonymous function name to file it was called from', t => {
+  t.plan(1)
+
+  const fn = fp((fastify, opts, next) => {
+    next()
+  })
+
+  t.is(fn[fp.DISPLAY_NAME_SYMBOL], 'test')
+})

--- a/test.js
+++ b/test.js
@@ -178,5 +178,5 @@ test('should set anonymous function name to file it was called from', t => {
     next()
   })
 
-  t.is(fn[Symbol('fastify.display-name')], 'test')
+  t.is(fn[Symbol.for('fastify.display-name')], 'test')
 })


### PR DESCRIPTION
Related to https://github.com/fastify/fastify/pull/861

When a user adds a fastify plugin with an anonymous name, `fp` will use look up the stack trace and set the function objects display name to be the file name from which it was called. It stores this in a symbol: `fp.DISPLAY_NAME_SYMBOL`

For example:
```javascript
// mySuperDuperPlugin.js
const fp = require('fp')

const fn = fp((fastify, opts, next) => {
  next()
})

console.log(fn[fp.DISPLAY_NAME_SYMBOL]) // 'mySuperDuperPlugin'
```

I've also added a unit test.
Regular expressions should work in Node version 6+ too