### PR TITLE
have fp use meta name option instead of new symbol

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,9 @@ function plugin (fn, options = {}) {
   }
 
   if (!options.name) {
-    options.name = checkName(fn)
+    let name = checkName(fn)
+    options.name = name
+    fn[Symbol.for('fastify.display-name')] = name
   }
 
   if (options.fastify) {

--- a/index.js
+++ b/index.js
@@ -23,8 +23,7 @@ function plugin (fn, options = {}) {
   }
 
   if (!options.name) {
-    let name = checkName(fn)
-    options.name = name
+    options.name = checkName(fn)
   }
 
   fn[Symbol.for('fastify.display-name')] = options.name

--- a/index.js
+++ b/index.js
@@ -3,28 +3,27 @@
 const semver = require('semver')
 const console = require('console')
 
-const DISPLAY_NAME_SYMBOL = Symbol.for('fastify.display-name')
 const fpStackTracePattern = new RegExp('at\\s{1}(?:.*\\.)?plugin\\s{1}.*\\n\\s*(.*)')
 const fileNamePattern = new RegExp('(?:\\/|\\\\)(\\w*(\\.\\w*)*)\\..*')
 
-function plugin (fn, options) {
+function plugin (fn, options = {}) {
   if (typeof fn !== 'function') {
     throw new TypeError(`fastify-plugin expects a function, instead got a '${typeof fn}'`)
   }
 
-  fn[DISPLAY_NAME_SYMBOL] = checkName(fn)
-
   fn[Symbol.for('skip-override')] = true
-
-  if (options === undefined) return fn
 
   if (typeof options === 'string') {
     checkVersion(options)
-    return fn
+    options = {}
   }
 
   if (typeof options !== 'object' || Array.isArray(options) || options === null) {
     throw new TypeError('The options object should be an object')
+  }
+
+  if (!options.name) {
+    options.name = checkName(fn)
   }
 
   if (options.fastify) {

--- a/index.js
+++ b/index.js
@@ -25,8 +25,9 @@ function plugin (fn, options = {}) {
   if (!options.name) {
     let name = checkName(fn)
     options.name = name
-    fn[Symbol.for('fastify.display-name')] = name
   }
+
+  fn[Symbol.for('fastify.display-name')] = options.name
 
   if (options.fastify) {
     checkVersion(options.fastify)

--- a/test/composite.test.js
+++ b/test/composite.test.js
@@ -5,11 +5,12 @@ const test = t.test
 const fp = require('./../')
 
 test('anonymous function should be named composite.test', t => {
-  t.plan(1)
+  t.plan(2)
 
   const fn = fp((fastify, opts, next) => {
     next()
   })
 
   t.is(fn[Symbol.for('plugin-meta')].name, 'composite.test')
+  t.is(fn[Symbol.for('fastify.display-name')], 'composite.test')
 })

--- a/test/composite.test.js
+++ b/test/composite.test.js
@@ -11,5 +11,5 @@ test('anonymous function should be named composite.test', t => {
     next()
   })
 
-  t.is(fn[Symbol.for('fastify.display-name')], 'composite.test')
+  t.is(fn[Symbol.for('plugin-meta')].name, 'composite.test')
 })

--- a/test/composite.test.ts
+++ b/test/composite.test.ts
@@ -4,11 +4,12 @@ import * as tap from 'tap'
 const test = tap.test
 
 test('anonymous function should be named composite.test', (t: any) => {
-  t.plan(1)
+  t.plan(2)
 
   const fn = fp((fastify, opts, next) => {
     next()
   })
 
   t.is(fn[Symbol.for('plugin-meta')].name, 'composite.test')
+  t.is(fn[Symbol.for('fastify.display-name')], 'composite.test')
 })

--- a/test/composite.test.ts
+++ b/test/composite.test.ts
@@ -10,5 +10,5 @@ test('anonymous function should be named composite.test', (t: any) => {
     next()
   })
 
-  t.is(fn[Symbol.for('fastify.display-name')], 'composite.test')
+  t.is(fn[Symbol.for('plugin-meta')].name, 'composite.test')
 })

--- a/test/composite.ts
+++ b/test/composite.ts
@@ -4,11 +4,12 @@ import * as tap from 'tap'
 const test = tap.test
 
 test('anonymous function should be named composite.test', (t: any) => {
-  t.plan(1)
+  t.plan(2)
 
   const fn = fp((fastify, opts, next) => {
     next()
   })
 
   t.is(fn[Symbol.for('plugin-meta')].name, 'composite')
+  t.is(fn[Symbol.for('fastify.display-name')], 'composite')
 })

--- a/test/composite.ts
+++ b/test/composite.ts
@@ -10,5 +10,5 @@ test('anonymous function should be named composite.test', (t: any) => {
     next()
   })
 
-  t.is(fn[Symbol.for('fastify.display-name')], 'composite')
+  t.is(fn[Symbol.for('plugin-meta')].name, 'composite')
 })

--- a/test/mu1tip1e.composite.test.js
+++ b/test/mu1tip1e.composite.test.js
@@ -5,11 +5,12 @@ const test = t.test
 const fp = require('./../')
 
 test('anonymous function should be named mu1tip1e.composite.test', t => {
-  t.plan(1)
+  t.plan(2)
 
   const fn = fp((fastify, opts, next) => {
     next()
   })
 
   t.is(fn[Symbol.for('plugin-meta')].name, 'mu1tip1e.composite.test')
+  t.is(fn[Symbol.for('fastify.display-name')], 'mu1tip1e.composite.test')
 })

--- a/test/mu1tip1e.composite.test.js
+++ b/test/mu1tip1e.composite.test.js
@@ -11,5 +11,5 @@ test('anonymous function should be named mu1tip1e.composite.test', t => {
     next()
   })
 
-  t.is(fn[Symbol.for('fastify.display-name')], 'mu1tip1e.composite.test')
+  t.is(fn[Symbol.for('plugin-meta')].name, 'mu1tip1e.composite.test')
 })

--- a/test/mu1tip1e.composite.test.ts
+++ b/test/mu1tip1e.composite.test.ts
@@ -5,11 +5,12 @@ import * as tap from 'tap'
 const test = tap.test
 
 test('anonymous function should be named mu1tip1e.composite.test', t => {
-  t.plan(1)
+  t.plan(2)
 
   const fn = fp((fastify, opts, next) => {
     next()
   })
 
   t.is(fn[Symbol.for('plugin-meta')].name, 'mu1tip1e.composite.test')
+  t.is(fn[Symbol.for('fastify.display-name')], 'mu1tip1e.composite.test')
 })

--- a/test/mu1tip1e.composite.test.ts
+++ b/test/mu1tip1e.composite.test.ts
@@ -11,5 +11,5 @@ test('anonymous function should be named mu1tip1e.composite.test', t => {
     next()
   })
 
-  t.is(fn[Symbol.for('fastify.display-name')], 'mu1tip1e.composite.test')
+  t.is(fn[Symbol.for('plugin-meta')].name, 'mu1tip1e.composite.test')
 })

--- a/test/test.js
+++ b/test/test.js
@@ -172,11 +172,12 @@ test('should throw if the fastify version does not satisfies the plugin requeste
 })
 
 test('should set anonymous function name to file it was called from', t => {
-  t.plan(1)
+  t.plan(2)
 
   const fn = fp((fastify, opts, next) => {
     next()
   })
 
   t.is(fn[Symbol.for('plugin-meta')].name, 'test')
+  t.is(fn[Symbol.for('fastify.display-name')], 'test')
 })

--- a/test/test.js
+++ b/test/test.js
@@ -178,5 +178,5 @@ test('should set anonymous function name to file it was called from', t => {
     next()
   })
 
-  t.is(fn[Symbol.for('fastify.display-name')], 'test')
+  t.is(fn[Symbol.for('plugin-meta')].name, 'test')
 })

--- a/test/test.js
+++ b/test/test.js
@@ -181,3 +181,16 @@ test('should set anonymous function name to file it was called from', t => {
   t.is(fn[Symbol.for('plugin-meta')].name, 'test')
   t.is(fn[Symbol.for('fastify.display-name')], 'test')
 })
+
+test('should set display-name to meta name', t => {
+  t.plan(2)
+
+  const functionName = 'superDuperSpecialFunction'
+
+  const fn = fp((fastify, opts, next) => next(), {
+    name: functionName
+  })
+
+  t.is(fn[Symbol.for('plugin-meta')].name, functionName)
+  t.is(fn[Symbol.for('fastify.display-name')], functionName)
+})

--- a/test/test.ts
+++ b/test/test.ts
@@ -10,5 +10,5 @@ test('should set anonymous function name to file it was called from', t => {
     next()
   })
 
-  t.is(fn[Symbol.for('fastify.display-name')], 'test')
+  t.is(fn[Symbol.for('plugin-meta')].name, 'test')
 })

--- a/test/test.ts
+++ b/test/test.ts
@@ -4,11 +4,12 @@ import * as tap from 'tap'
 const test = tap.test
 
 test('should set anonymous function name to file it was called from', t => {
-  t.plan(1)
+  t.plan(2)
 
   const fn = fp((fastify, opts, next) => {
     next()
   })
 
   t.is(fn[Symbol.for('plugin-meta')].name, 'test')
+  t.is(fn[Symbol.for('fastify.display-name')], 'test')
 })


### PR DESCRIPTION
@nwoltman highlighted that `fastify` uses the `fastify-plugin` `options.name` meta option property when adding plugins to the `registered-plugin` list. In conjunction with the new `toString` feature (https://github.com/fastify/fastify/pull/861) this PR includes changes that will make `fp` always assign a function name to the meta option object instead of using an independent symbol (previously added via https://github.com/fastify/fastify-plugin/pull/37). 

Due note that this will change the fundamental behavior of `fastify-plugin` as it will **always** assign the `Symbol.for('plugin-meta')` property to every function passed in. 

I kept support for using a version string as the 'options' parameter too.