### PR TITLE
Adds defaults generic types to main function

### DIFF
--- a/fastify-plugin.d.ts
+++ b/fastify-plugin.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="fastify" />
 
 import * as fastify from 'fastify';
+import { Server, IncomingMessage, ServerResponse } from 'http'
 
 /**
  * This function does three things for you:
@@ -11,7 +12,7 @@ import * as fastify from 'fastify';
  * @param options Optional plugin options
  * @param next The `next` callback is not available when using `async`/`await`. If you do invoke a `next` callback in this situation unexpected behavior may occur.
  */
-declare function fastifyPlugin<HttpServer, HttpRequest, HttpResponse, T>(
+declare function fastifyPlugin<HttpServer = Server, HttpRequest = IncomingMessage, HttpResponse = ServerResponse, T = any>(
   fn: fastify.Plugin<HttpServer, HttpRequest, HttpResponse, T> | { default: fastify.Plugin<HttpServer, HttpRequest, HttpResponse, T> },
   options?: fastifyPlugin.PluginOptions | string,
   next?: fastifyPlugin.nextCallback

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -34,3 +34,4 @@ export const testPluginWithAsync = fp(
 const server = fastify()
 
 server.register(testPlugin) // register expects a fastify.Plugin
+server.register(testPluginWithCallback) // test fastify.Plugin's gerneric typings


### PR DESCRIPTION
This PR matches https://github.com/fastify/fastify/pull/1669
If nothing is passed the `{}` are assigned as defaults and it makes every plugin added not usable as register argument in TS.
The compiler error is:
```
Argument of type 'Plugin<{}, {}, {}, {}>' is not assignable to parameter of type 'Plugin<Server, IncomingMessage, ServerResponse, {}>'.
  Type '{}' is missing the following properties from type 'Server': setTimeout, maxHeadersCount, timeout, headersTimeout, and 25 more.
```
This is a bug already present in fastify, also before `pull/1669` merge.