### PR TITLE
support base-options Symbol for fastify-autoload compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ module.exports = fp(plugin, {
 })
 ```
 
+#### Base Options
+
+If a plugin has a `options` property, `fastify-plugin` will automatically reference this options object on a `Symbol.for('base-options')` as well. This provides seamless compatibility with [`fastify-autoload`](https://github.com/fastify/fastify-autoload) plugin configuration options shorthand feature.
+
 ## Acknowledgements
 
 This project is kindly sponsored by:

--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ function plugin (fn, options = {}) {
 
   fn[Symbol.for('skip-override')] = true
 
+  if (typeof fn.options === 'object' && fn.options !== null) {
+    fn[Symbol.for('base-options')] = fn.options
+  }
+
   if (typeof options === 'string') {
     checkVersion(options)
     options = {}

--- a/index.js
+++ b/index.js
@@ -15,8 +15,8 @@ function plugin (fn, options = {}) {
 
   fn[Symbol.for('skip-override')] = true
 
-  if (typeof fn.options === 'object' && fn.options !== null) {
-    fn[Symbol.for('base-options')] = fn.options
+  if (typeof fn.autoConfig === 'object' && fn.autoConfig !== null) {
+    fn[Symbol.for('fastify-auto-connfig')] = fn.autoConfig
   }
 
   if (typeof options === 'string') {

--- a/test/test.js
+++ b/test/test.js
@@ -288,5 +288,5 @@ test('should return the function with a base-options Symbol when an options prop
   }
   plugin.options = { some: 'options' }
   fp(plugin)
-  t.is(plugin[Symbol.for('base-options')], plugin.options)
+  t.is(plugin[Symbol.for('fastify-auto-config')], plugin.autoConfig)
 })

--- a/test/test.js
+++ b/test/test.js
@@ -279,3 +279,14 @@ test('should check fastify dependency graph - decorateReply', t => {
     t.is(err.message, "The decorator 'plugin2' is not present in Reply")
   })
 })
+
+test('should return the function with a base-options Symbol when an options property exists', t => {
+  t.plan(1)
+
+  function plugin (fastify, opts, next) {
+    next()
+  }
+  plugin.options = { some: 'options' }
+  fp(plugin)
+  t.is(plugin[Symbol.for('base-options')], plugin.options)
+})


### PR DESCRIPTION
This is a counterpart https://github.com/fastify/fastify-autoload/pull/60

It's here to support a `plugin.options` key for autoloading plugins (in line with fastify-cli -o flag) where a plugin can both declare it's "base options" and have them over ridden during autoloading without collisions - and without wiping out the original plugin.options

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->



#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
