### PR TITLE
Fix plugin metadata interface [TypeScript]

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -15,11 +15,11 @@ import {
  */
 export default function fp<Options>(
   fn: FastifyPluginCallback<Options>,
-  options?: PluginOptions,
+  options?: PluginMetadata,
 ): FastifyPluginCallback<Options>;
 export default function fp<Options>(
   fn: FastifyPluginAsync<Options>,
-  options?: PluginOptions,
+  options?: PluginMetadata,
 ): FastifyPluginAsync<Options>;
 
 export default function fp<Options>(
@@ -31,7 +31,7 @@ export default function fp<Options>(
   options?: string,
 ): FastifyPluginAsync<Options>;
 
-export interface PluginOptions {
+export interface PluginMetadata {
   /** Bare-minimum version of Fastify for your plugin, just add the semver range that you need. */
   fastify?: string,
   name?: string,
@@ -44,5 +44,8 @@ export interface PluginOptions {
   /** The plugin dependencies */
   dependencies?: string[]
 }
+
+// Exporting PluginOptions for backward compatibility after renaming it to PluginMetadata
+export interface PluginOptions extends PluginMetadata {}
 
 export type NextCallback = (err?: Error) => void;

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -15,11 +15,11 @@ import {
  */
 export default function fp<Options>(
   fn: FastifyPluginCallback<Options>,
-  options?: Options & PluginOptions,
+  options?: PluginOptions,
 ): FastifyPluginCallback<Options>;
 export default function fp<Options>(
   fn: FastifyPluginAsync<Options>,
-  options?: Options & PluginOptions,
+  options?: PluginOptions,
 ): FastifyPluginAsync<Options>;
 
 export default function fp<Options>(

--- a/plugin.test-d.ts
+++ b/plugin.test-d.ts
@@ -18,8 +18,7 @@ export const testPluginWithCallback: FastifyPlugin<TestOptions> = fp(
     fastify.decorate('utility', () => { })
     next();
     return;
-  },
-  { customNumber: 1 },
+  }
 )
 
 export const testPluginWithAsync = fp<TestOptions>(
@@ -27,7 +26,6 @@ export const testPluginWithAsync = fp<TestOptions>(
     fastify.decorate('utility', () => { })
   },
   {
-    customNumber: 2,
     fastify: '>=1',
     name: 'TestPlugin',
     decorators: {
@@ -40,8 +38,11 @@ export const testPluginWithAsync = fp<TestOptions>(
 const server = fastify()
 
 server.register(testPluginWithOptions) // register expects a FastifyPlugin
-server.register(testPluginWithCallback)
-server.register(testPluginWithAsync)
+server.register(testPluginWithCallback, { customNumber: 2 })
+server.register(testPluginWithAsync, { customNumber: 3 })
+expectError(server.register(testPluginWithCallback, { })) // invalid options passed to plugin on registration
+expectError(server.register(testPluginWithAsync, { customNumber: '2' })) // invalid type in options passed to plugin on registration
+
 
 // Register with HTTP2
 const serverWithHttp2 = fastify({ http2: true });


### PR DESCRIPTION
Fixes #91 

I've taken the liberty to rename `PluginOptions` to `PluginMetadata` and I'm exporting `PluginOptions` for backward compatibility. If sticking to `PluginOptions` is preferred, let me know and I'll revert this change.

I don't see any docs that need update, but let me know if I missed something.


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
