### PR TITLE
Add fastify as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "tsd": "^0.11.0",
     "typescript": "^3.8.2"
   },
+  "peerDependencies": {
+    "fastify": "^3.0.0"
+  },
   "dependencies": {
     "semver": "^7.3.2"
   }


### PR DESCRIPTION
This PR adds fastify as a peer dependency so that it works properly with Yarn v2 without having to override the package. Without it you'll get the following message in your log for every plugin since it is trying to require `fastify/package.json`:
```
fastify not found, proceeding anyway
```
Yarn v2 enforces packages to list all dependencies that are used by that package. In this case, fastify is provided by the user so it should be a peer dependency.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
