### PR TITLE
Automatic name must be unique

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -5,6 +5,8 @@ const console = require('console')
 const extractPluginName = require('./stackParser')
 const { join, dirname } = require('path')
 
+let count = 0
+
 function plugin (fn, options = {}) {
   if (typeof fn.default !== 'undefined') { // Support for 'export default' behaviour in transpiled ECMAScript module
     fn = fn.default
@@ -28,7 +30,7 @@ function plugin (fn, options = {}) {
   }
 
   if (!options.name) {
-    options.name = pluginName
+    options.name = pluginName + count++
   }
 
   fn[Symbol.for('fastify.display-name')] = options.name

--- a/plugin.js
+++ b/plugin.js
@@ -30,7 +30,7 @@ function plugin (fn, options = {}) {
   }
 
   if (!options.name) {
-    options.name = pluginName + count++
+    options.name = pluginName + '-auto-' + count++
   }
 
   fn[Symbol.for('fastify.display-name')] = options.name

--- a/test/composite.test.js
+++ b/test/composite.test.js
@@ -4,13 +4,13 @@ const t = require('tap')
 const test = t.test
 const fp = require('../plugin')
 
-test('anonymous function should be named composite.test', t => {
+test('anonymous function should be named composite.test0', t => {
   t.plan(2)
 
   const fn = fp((fastify, opts, next) => {
     next()
   })
 
-  t.is(fn[Symbol.for('plugin-meta')].name, 'composite.test')
-  t.is(fn[Symbol.for('fastify.display-name')], 'composite.test')
+  t.is(fn[Symbol.for('plugin-meta')].name, 'composite.test0')
+  t.is(fn[Symbol.for('fastify.display-name')], 'composite.test0')
 })

--- a/test/composite.test.js
+++ b/test/composite.test.js
@@ -11,6 +11,6 @@ test('anonymous function should be named composite.test0', t => {
     next()
   })
 
-  t.is(fn[Symbol.for('plugin-meta')].name, 'composite.test0')
-  t.is(fn[Symbol.for('fastify.display-name')], 'composite.test0')
+  t.is(fn[Symbol.for('plugin-meta')].name, 'composite.test-auto-0')
+  t.is(fn[Symbol.for('fastify.display-name')], 'composite.test-auto-0')
 })

--- a/test/mu1tip1e.composite.test.js
+++ b/test/mu1tip1e.composite.test.js
@@ -11,6 +11,6 @@ test('anonymous function should be named mu1tip1e.composite.test', t => {
     next()
   })
 
-  t.is(fn[Symbol.for('plugin-meta')].name, 'mu1tip1e.composite.test')
-  t.is(fn[Symbol.for('fastify.display-name')], 'mu1tip1e.composite.test')
+  t.is(fn[Symbol.for('plugin-meta')].name, 'mu1tip1e.composite.test0')
+  t.is(fn[Symbol.for('fastify.display-name')], 'mu1tip1e.composite.test0')
 })

--- a/test/mu1tip1e.composite.test.js
+++ b/test/mu1tip1e.composite.test.js
@@ -11,6 +11,6 @@ test('anonymous function should be named mu1tip1e.composite.test', t => {
     next()
   })
 
-  t.is(fn[Symbol.for('plugin-meta')].name, 'mu1tip1e.composite.test0')
-  t.is(fn[Symbol.for('fastify.display-name')], 'mu1tip1e.composite.test0')
+  t.is(fn[Symbol.for('plugin-meta')].name, 'mu1tip1e.composite.test-auto-0')
+  t.is(fn[Symbol.for('fastify.display-name')], 'mu1tip1e.composite.test-auto-0')
 })

--- a/test/test.js
+++ b/test/test.js
@@ -210,15 +210,15 @@ test('should set anonymous function name to file it was called from with a count
     next()
   })
 
-  t.is(fn[Symbol.for('plugin-meta')].name, 'test0')
-  t.is(fn[Symbol.for('fastify.display-name')], 'test0')
+  t.is(fn[Symbol.for('plugin-meta')].name, 'test-auto-0')
+  t.is(fn[Symbol.for('fastify.display-name')], 'test-auto-0')
 
   const fn2 = fp((fastify, opts, next) => {
     next()
   })
 
-  t.is(fn2[Symbol.for('plugin-meta')].name, 'test1')
-  t.is(fn2[Symbol.for('fastify.display-name')], 'test1')
+  t.is(fn2[Symbol.for('plugin-meta')].name, 'test-auto-1')
+  t.is(fn2[Symbol.for('fastify.display-name')], 'test-auto-1')
 
   t.end()
 })

--- a/test/test.js
+++ b/test/test.js
@@ -203,15 +203,24 @@ test('should throw if the fastify version does not satisfies the plugin requeste
   }
 })
 
-test('should set anonymous function name to file it was called from', t => {
-  t.plan(2)
+test('should set anonymous function name to file it was called from with a counter', t => {
+  const fp = proxyquire('../plugin.js', { stubs: {} })
 
   const fn = fp((fastify, opts, next) => {
     next()
   })
 
-  t.is(fn[Symbol.for('plugin-meta')].name, 'test')
-  t.is(fn[Symbol.for('fastify.display-name')], 'test')
+  t.is(fn[Symbol.for('plugin-meta')].name, 'test0')
+  t.is(fn[Symbol.for('fastify.display-name')], 'test0')
+
+  const fn2 = fp((fastify, opts, next) => {
+    next()
+  })
+
+  t.is(fn2[Symbol.for('plugin-meta')].name, 'test1')
+  t.is(fn2[Symbol.for('fastify.display-name')], 'test1')
+
+  t.end()
 })
 
 test('should set display-name to meta name', t => {


### PR DESCRIPTION
Certain plugins (e.g. fastify-autoload) use the name to disambiguate
between plugins and create a map of registered plugins so it can check
for interdependencies. In case two plugins have the same name,
fastify-autoload will not load them. This commit makes the name
unique by adding an integer at the end.

Fixes https://github.com/fastify/fastify-cli/pull/256

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
