### PR TITLE
Support faux modules

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -41,6 +41,11 @@ function plugin (fn, options = {}) {
 
   fn[Symbol.for('plugin-meta')] = options
 
+  // Faux modules support
+  if (!fn.default) {
+    fn.default = fn
+  }
+
   return fn
 }
 

--- a/test/bundlers.test.js
+++ b/test/bundlers.test.js
@@ -30,7 +30,7 @@ test('support faux modules', (t) => {
   const plugin = fp((fastify, opts, next) => {
     next()
   })
-  
+
   t.is(plugin.default, plugin)
   t.end()
 })

--- a/test/bundlers.test.js
+++ b/test/bundlers.test.js
@@ -25,3 +25,12 @@ test('webpack removes require.main.filename', (t) => {
 
   t.end()
 })
+
+test('support faux modules', (t) => {
+  const plugin = fp((fastify, opts, next) => {
+    next()
+  })
+  
+  t.is(plugin.default, plugin)
+  t.end()
+})


### PR DESCRIPTION
Automatically add a `default` property on the plugin function so that
faux modules importing it can find it.
It avoids creating a PR to fix this in the whole ecosystem.


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
