### PR TITLE
Removes wrong "files" setting from tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,5 @@
     "module": "commonjs",
     "noEmit": true,
     "strict": true,
-  },
-  "files": [
-    "./test/types.test.ts"
-  ]
+  }
 }


### PR DESCRIPTION
Since [tsd](https://www.npmjs.com/package/tsd) uses its own file structure and naming, there is no need to provide "files" in tsconfig.json. In addition to that, the setting was wrong.

#### Checklist
- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
