### PR TITLE
Adds default to module.exports

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -122,4 +122,5 @@ function checkVersion (version, pluginName) {
   }
 }
 
+plugin.default = plugin
 module.exports = plugin


### PR DESCRIPTION
Fixes: https://github.com/fastify/fastify-plugin/issues/105

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
