### PR TITLE
increase coverage

### DIFF
--- a/test/bundlers.test.js
+++ b/test/bundlers.test.js
@@ -35,6 +35,19 @@ test('support faux modules', (t) => {
   t.end()
 })
 
+test('support faux modules does not override existing default field in babel module', (t) => {
+  const module = {
+    default: (fastify, opts, next) => next()
+  }
+
+  module.default.default = 'Existing default field'
+
+  const plugin = fp(module)
+
+  t.equal(plugin.default, 'Existing default field')
+  t.end()
+})
+
 test('support ts named imports', (t) => {
   const plugin = fp((fastify, opts, next) => {
     next()


### PR DESCRIPTION
- [x] run `npm run test`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Added test after feature to support faux modules.
It will cover the else statement in plugin.js:52

https://github.com/fastify/fastify-plugin/issues/134