### PR TITLE
add symbol type to decorators

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -24,9 +24,9 @@ export interface PluginMetadata {
   name?: string,
   /** Decorator dependencies for this plugin */
   decorators?: {
-    fastify?: string[],
-    reply?: string[],
-    request?: string[]
+    fastify?: (string | symbol)[],
+    reply?: (string | symbol)[],
+    request?: (string | symbol)[]
   },
   /** The plugin dependencies */
   dependencies?: string[]

--- a/plugin.test-d.ts
+++ b/plugin.test-d.ts
@@ -6,6 +6,8 @@ interface Options {
   foo: string
 }
 
+const testSymbol = Symbol('foobar')
+
 // Callback
 
 const pluginCallback: FastifyPluginCallback = (fastify, options, next) => { }
@@ -21,9 +23,9 @@ expectAssignable<FastifyPluginCallback>(fp(pluginCallback, {
   fastify: '',
   name: '',
   decorators: {
-    fastify: [ '' ],
-    reply: [ '' ],
-    request: [ '' ]
+    fastify: [ '', testSymbol ],
+    reply: [ '', testSymbol ],
+    request: [ '', testSymbol ]
   },
   dependencies: [ '' ]
 }))
@@ -48,9 +50,9 @@ expectAssignable<FastifyPluginAsync>(fp(pluginAsync, {
   fastify: '',
   name: '',
   decorators: {
-    fastify: [ '' ],
-    reply: [ '' ],
-    request: [ '' ]
+    fastify: [ '', testSymbol ],
+    reply: [ '', testSymbol ],
+    request: [ '', testSymbol ]
   },
   dependencies: [ '' ]
 }))


### PR DESCRIPTION
fastify decorators can be either of type string or symbol, the later was missing from the typings

#### Checklist

- [X] run `npm run test` and `npm run benchmark` (benchmark script isnt present?)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
