### PR TITLE
types: Export types in a way compatible with TypeScript `"moduleResolution"`: `"NodeNext"`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "standard && tap test/*.js test/esm/*.js --no-check-coverage && npm run typescript",
     "test:ci": "standard && tap test/*.js test/esm/*.js --no-check-coverage --coverage-report=lcovonly && npm run typescript",
-    "typescript": "tsd"
+    "typescript": "tsd && tsd --files test/*.test-d.ts"
   },
   "repository": {
     "type": "git",

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -74,6 +74,8 @@ declare namespace fp {
   // Exporting PluginOptions for backward compatibility after renaming it to PluginMetadata
   export interface PluginOptions extends PluginMetadata {}
 
+  // default export for ESM
+  export { fp as default } 
 }
 
 export = fp;

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -18,16 +18,16 @@ import {
  * @param fn Fastify plugin function
  * @param options Optional plugin options
  */
-export default function fp<
+declare function fp<
   Options extends FastifyPluginOptions,
   RawServer extends RawServerBase = RawServerDefault,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault
 >(
   fn: FastifyPluginAsync<Options, RawServer, TypeProvider>,
-  options?: PluginMetadata
+  options?: fp.PluginMetadata
 ): FastifyPluginAsync<Options, RawServer, TypeProvider>;
 
-export default function fp<
+declare function fp<
   Options extends FastifyPluginOptions,
   RawServer extends RawServerBase = RawServerDefault,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault
@@ -36,16 +36,16 @@ export default function fp<
   options?: string
 ): FastifyPluginAsync<Options, RawServer, TypeProvider>;
 
-export default function fp<
+declare function fp<
   Options extends FastifyPluginOptions,
   RawServer extends RawServerBase = RawServerDefault,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault
 >(
   fn: FastifyPluginCallback<Options, RawServer, TypeProvider>,
-  options?: PluginMetadata
+  options?: fp.PluginMetadata
 ): FastifyPluginCallback<Options, RawServer, TypeProvider>;
 
-export default function fp<
+declare function fp<
   Options extends FastifyPluginOptions,
   RawServer extends RawServerBase = RawServerDefault,
   TypeProvider extends FastifyTypeProvider = FastifyTypeProviderDefault
@@ -54,20 +54,26 @@ export default function fp<
   options?: string
 ): FastifyPluginCallback<Options>;
 
-export interface PluginMetadata {
-  /** Bare-minimum version of Fastify for your plugin, just add the semver range that you need. */
-  fastify?: string,
-  name?: string,
-  /** Decorator dependencies for this plugin */
-  decorators?: {
-    fastify?: (string | symbol)[],
-    reply?: (string | symbol)[],
-    request?: (string | symbol)[]
-  },
-  /** The plugin dependencies */
-  dependencies?: string[],
-  encapsulate?: boolean
+declare namespace fp {
+
+  export interface PluginMetadata {
+    /** Bare-minimum version of Fastify for your plugin, just add the semver range that you need. */
+    fastify?: string,
+    name?: string,
+    /** Decorator dependencies for this plugin */
+    decorators?: {
+      fastify?: (string | symbol)[],
+      reply?: (string | symbol)[],
+      request?: (string | symbol)[]
+    },
+    /** The plugin dependencies */
+    dependencies?: string[],
+    encapsulate?: boolean
+  }
+
+  // Exporting PluginOptions for backward compatibility after renaming it to PluginMetadata
+  export interface PluginOptions extends PluginMetadata {}
+
 }
 
-// Exporting PluginOptions for backward compatibility after renaming it to PluginMetadata
-export interface PluginOptions extends PluginMetadata {}
+export = fp;

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -1,0 +1,41 @@
+import { expectAssignable, expectError, expectNotAssignable, expectType, } from 'tsd';
+import { FastifyPluginOptions, FastifyPluginAsync } from 'fastify';
+
+// ESM default-import style
+import fp1, { PluginOptions } from '../plugin';
+let opts1a!: PluginOptions
+let opts1b!: fp1.PluginOptions
+let opts1c!: fp1.default.PluginOptions
+expectAssignable<Function>(fp1);
+expectAssignable<Function>(fp1.default);
+expectAssignable<FastifyPluginOptions>(opts1a);
+expectAssignable<FastifyPluginOptions>(opts1b);
+expectAssignable<FastifyPluginOptions>(opts1c);
+expectType<FastifyPluginAsync>(fp1(async () => {}));
+expectType<FastifyPluginAsync>(fp1.default(async () => {}));
+
+// ESM alternative import style
+import { default as fp2, PluginOptions as PluginOptions2 } from '../plugin';
+let opts2a!: PluginOptions2
+let opts2b!: fp2.PluginOptions
+let opts2c!: fp2.default.PluginOptions
+expectAssignable<Function>(fp2);
+expectAssignable<Function>(fp2.default);
+expectAssignable<FastifyPluginOptions>(opts2a);
+expectAssignable<FastifyPluginOptions>(opts2b);
+expectAssignable<FastifyPluginOptions>(opts2c);
+expectType<FastifyPluginAsync>(fp2(async () => {}));
+expectType<FastifyPluginAsync>(fp2.default(async () => {}));
+
+// Star-import style
+import * as fp3 from '../plugin';
+let opts3a!: PluginOptions2
+let opts3b!: fp3.PluginOptions
+let opts3c!: fp3.default.PluginOptions
+expectNotAssignable<Function>(fp3);
+expectAssignable<Function>(fp3.default);
+expectAssignable<FastifyPluginOptions>(opts3a);
+expectAssignable<FastifyPluginOptions>(opts3b);
+expectAssignable<FastifyPluginOptions>(opts3c);
+expectError(fp3(async () => {}));
+expectType<FastifyPluginAsync>(fp3.default(async () => {}));


### PR DESCRIPTION
This is a typing issue only, not a runtime isse. Since TypeScript `4.8.3`, when using `"moduleResolution": "NodeNext"` (or `"Node16"`) for an ESM project, TypeScript will now report an error when using the code below:

```TypeScript
import fp from 'fastify-plugin';

export default fp(...); // Error: This expression is not callable. Type 'typeof import(".../node_modules/fastify-plugin/plugin")' has no call signatures.
```

My own understanding is limited, but there has been a lot of discussion, for example microsoft/TypeScript#48845. Basically I think it is because the typings descibe the module as an ES module with a default export (which would be correct if the module was an ES module), but it is actually a CJS module exporing the `plugin` function with a `default` property...

Either way, I've tested this PR in an ESM project with `"moduleResolution"`: `"Node"` and `"moduleResolution"`: `"NodeNext"` (or `"Node16"`) and it compiles successfully for both.


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] ~tests and/or benchmarks are included~
- [x] ~documentation is changed or added~
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
