### PR TITLE
fix unit test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,5 @@ jobs:
   test:
     uses: fastify/workflows/.github/workflows/plugins-ci.yml@v3
     with:
+      lint: true
       license-check: true

--- a/.taprc
+++ b/.taprc
@@ -2,3 +2,6 @@ ts: false
 jsx: false
 flow: false
 coverage: true
+
+files:
+  - test/**/*.js

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "main": "plugin.js",
   "types": "plugin.d.ts",
   "scripts": {
-    "test": "standard && tap test/*.js test/esm/*.js --no-check-coverage && npm run typescript",
-    "test:ci": "standard && tap test/*.js test/esm/*.js --no-check-coverage --coverage-report=lcovonly && npm run typescript",
-    "typescript": "tsd"
+    "lint": "standard",
+    "test": "npm run test:unit && npm run test:typescript",
+    "test:unit": "tap",
+    "test:typescript": "tsd"
   },
   "repository": {
     "type": "git",
@@ -29,7 +30,6 @@
     "@types/node": "^18.0.0",
     "fastify": "^4.0.1",
     "proxyquire": "^2.1.3",
-    "semver": "^7.3.7",
     "standard": "^17.0.0",
     "tap": "^16.0.1",
     "tsd": "^0.24.1"

--- a/test/esm/index.test.js
+++ b/test/esm/index.test.js
@@ -1,19 +1,11 @@
 'use strict'
 
-const t = require('tap')
-const semver = require('semver')
-
-if (semver.lt(process.versions.node, '13.3.0')) {
-  t.skip('Skip because Node version <= 13.3.0')
-  t.end()
-} else {
-  // Node v8 throw a `SyntaxError: Unexpected token import`
-  // even if this branch is never touch in the code,
-  // by using `eval` we can avoid this issue.
-  // eslint-disable-next-line
-  new Function('module', 'return import(module)')('./esm.mjs').catch((err) => {
-    process.nextTick(() => {
-      throw err
-    })
+// Node v8 throw a `SyntaxError: Unexpected token import`
+// even if this branch is never touch in the code,
+// by using `eval` we can avoid this issue.
+// eslint-disable-next-line
+new Function('module', 'return import(module)')('./esm.mjs').catch((err) => {
+  process.nextTick(() => {
+    throw err
   })
-}
+})

--- a/test/test.js
+++ b/test/test.js
@@ -299,7 +299,7 @@ test('should check version when encapsulated', t => {
   }))
 
   fastify.ready(err => {
-    t.match(err.message, /fastify-plugin: test - expected '<=2.10.0' fastify version, '\d.\d.\d' is installed/)
+    t.match(err.message, /fastify-plugin: test - expected '<=2.10.0' fastify version, '\d.\d+.\d+' is installed/)
   })
 })
 


### PR DESCRIPTION
The pattern to validate the fastify version is expecting only single digit minor and patch-version. Fastify 4 is now at minor version 10, so the tests fail, see e.g. the failed test un in #201 

also:
remove semver
improve npm scripts
activate linting on ci

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
