### PR TITLE
make getPluginName resilient against too low stackTraceLimit

### DIFF
--- a/lib/getPluginName.js
+++ b/lib/getPluginName.js
@@ -6,9 +6,12 @@ const fileNamePattern = /(\w*(\.\w*)*)\..*/
 module.exports = function getPluginName (fn) {
   if (fn.name.length > 0) return fn.name
 
+  const stackTraceLimit = Error.stackTraceLimit
+  Error.stackTraceLimit = 10
   try {
     throw new Error('anonymous function')
   } catch (e) {
+    Error.stackTraceLimit = stackTraceLimit
     return extractPluginName(e.stack)
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -155,6 +155,29 @@ test('should set anonymous function name to file it was called from with a count
   t.end()
 })
 
+test('should set function name if Error.stackTraceLimit is set to 0', t => {
+  const stackTraceLimit = Error.stackTraceLimit = 0
+
+  const fp = proxyquire('../plugin.js', { stubs: {} })
+
+  const fn = fp((fastify, opts, next) => {
+    next()
+  })
+
+  t.equal(fn[Symbol.for('plugin-meta')].name, 'test-auto-0')
+  t.equal(fn[Symbol.for('fastify.display-name')], 'test-auto-0')
+
+  const fn2 = fp((fastify, opts, next) => {
+    next()
+  })
+
+  t.equal(fn2[Symbol.for('plugin-meta')].name, 'test-auto-1')
+  t.equal(fn2[Symbol.for('fastify.display-name')], 'test-auto-1')
+
+  Error.stackTraceLimit = stackTraceLimit
+  t.end()
+})
+
 test('should set display-name to meta name', t => {
   t.plan(2)
 


### PR DESCRIPTION
If somebody sets Error.stackTraceLimit to 0, because there are some performance improvements, then getPluginName would not work properly. We set the stackTraceLimit to 10, which is default by node, so we ensure that getPluginName will still work properly.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
