### PR TITLE
fix: migrate from tap to node test and c8

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,4 +1,0 @@
-files:
-  - test/**/*.js
-plugin:
-  - "!@tapjs/typescript"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "lint": "standard",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap",
+    "test:unit": "node --test",
+    "test:coverage": "c8 node --test && c8 report --reporter=html",
     "test:typescript": "tsd"
   },
   "repository": {
@@ -30,10 +31,10 @@
     "@fastify/pre-commit": "^2.1.0",
     "@fastify/type-provider-typebox": "^5.0.0-pre.fv5.1",
     "@types/node": "^22.0.0",
+    "c8": "^10.1.2",
     "fastify": "^5.0.0-alpha.2",
     "proxyquire": "^2.1.3",
     "standard": "^17.1.0",
-    "tap": "^18.7.0",
     "tsd": "^0.31.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "standard",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "node --test",
+    "test:unit": "c8 --100 node --test",
     "test:coverage": "c8 node --test && c8 report --reporter=html",
     "test:typescript": "tsd"
   },

--- a/test/bundlers.test.js
+++ b/test/bundlers.test.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const fp = require('../plugin')
 
-test('webpack removes require.main.filename', (t) => {
+test('webpack removes require.main.filename', async (t) => {
   const filename = require.main.filename
   const info = console.info
-  t.teardown(() => {
+  t.after(() => {
     require.main.filename = filename
     console.info = info
   })
@@ -14,7 +14,7 @@ test('webpack removes require.main.filename', (t) => {
   require.main.filename = null
 
   console.info = function (msg) {
-    t.fail('logged: ' + msg)
+    t.assert.fail('logged: ' + msg)
   }
 
   fp((fastify, opts, next) => {
@@ -22,17 +22,14 @@ test('webpack removes require.main.filename', (t) => {
   }, {
     fastify: '^5.0.0'
   })
-
-  t.end()
 })
 
-test('support faux modules', (t) => {
+test('support faux modules', async (t) => {
   const plugin = fp((fastify, opts, next) => {
     next()
   })
 
-  t.equal(plugin.default, plugin)
-  t.end()
+  t.assert.strictEqual(plugin.default, plugin)
 })
 
 test('support faux modules does not override existing default field in babel module', (t) => {
@@ -44,66 +41,60 @@ test('support faux modules does not override existing default field in babel mod
 
   const plugin = fp(module)
 
-  t.equal(plugin.default, 'Existing default field')
-  t.end()
+  t.assert.strictEqual(plugin.default, 'Existing default field')
 })
 
-test('support ts named imports', (t) => {
+test('support ts named imports', async (t) => {
   const plugin = fp((fastify, opts, next) => {
     next()
   }, {
     name: 'hello'
   })
 
-  t.equal(plugin.hello, plugin)
-  t.end()
+  t.assert.strictEqual(plugin.hello, plugin)
 })
 
-test('from kebab-case to camelCase', (t) => {
+test('from kebab-case to camelCase', async (t) => {
   const plugin = fp((fastify, opts, next) => {
     next()
   }, {
     name: 'hello-world'
   })
 
-  t.equal(plugin.helloWorld, plugin)
-  t.end()
+  t.assert.strictEqual(plugin.helloWorld, plugin)
 })
 
-test('from @-prefixed named imports', (t) => {
+test('from @-prefixed named imports', async (t) => {
   const plugin = fp((fastify, opts, next) => {
     next()
   }, {
     name: '@hello/world'
   })
 
-  t.equal(plugin.helloWorld, plugin)
-  t.end()
+  t.assert.strictEqual(plugin.helloWorld, plugin)
 })
 
-test('from @-prefixed named kebab-case to camelCase', (t) => {
+test('from @-prefixed named kebab-case to camelCase', async (t) => {
   const plugin = fp((fastify, opts, next) => {
     next()
   }, {
     name: '@hello/my-world'
   })
 
-  t.equal(plugin.helloMyWorld, plugin)
-  t.end()
+  t.assert.strictEqual(plugin.helloMyWorld, plugin)
 })
 
-test('from kebab-case to camelCase multiple words', (t) => {
+test('from kebab-case to camelCase multiple words', async (t) => {
   const plugin = fp((fastify, opts, next) => {
     next()
   }, {
     name: 'hello-long-world'
   })
 
-  t.equal(plugin.helloLongWorld, plugin)
-  t.end()
+  t.assert.strictEqual(plugin.helloLongWorld, plugin)
 })
 
-test('from kebab-case to camelCase multiple words does not override', (t) => {
+test('from kebab-case to camelCase multiple words does not override', async (t) => {
   const fn = (fastify, opts, next) => {
     next()
   }
@@ -115,6 +106,5 @@ test('from kebab-case to camelCase multiple words does not override', (t) => {
     name: 'hello-long-world'
   })
 
-  t.equal(plugin.helloLongWorld, foobar)
-  t.end()
+  t.assert.strictEqual(plugin.helloLongWorld, foobar)
 })

--- a/test/bundlers.test.js
+++ b/test/bundlers.test.js
@@ -24,7 +24,7 @@ test('webpack removes require.main.filename', t => {
   })
 })
 
-test('support faux modules', async (t) => {
+test('support faux modules', (t) => {
   const plugin = fp((fastify, opts, next) => {
     next()
   })
@@ -44,7 +44,7 @@ test('support faux modules does not override existing default field in babel mod
   t.assert.strictEqual(plugin.default, 'Existing default field')
 })
 
-test('support ts named imports', async (t) => {
+test('support ts named imports', (t) => {
   const plugin = fp((fastify, opts, next) => {
     next()
   }, {
@@ -54,7 +54,7 @@ test('support ts named imports', async (t) => {
   t.assert.strictEqual(plugin.hello, plugin)
 })
 
-test('from kebab-case to camelCase', async (t) => {
+test('from kebab-case to camelCase', (t) => {
   const plugin = fp((fastify, opts, next) => {
     next()
   }, {
@@ -64,7 +64,7 @@ test('from kebab-case to camelCase', async (t) => {
   t.assert.strictEqual(plugin.helloWorld, plugin)
 })
 
-test('from @-prefixed named imports', async (t) => {
+test('from @-prefixed named imports', (t) => {
   const plugin = fp((fastify, opts, next) => {
     next()
   }, {
@@ -74,7 +74,7 @@ test('from @-prefixed named imports', async (t) => {
   t.assert.strictEqual(plugin.helloWorld, plugin)
 })
 
-test('from @-prefixed named kebab-case to camelCase', async (t) => {
+test('from @-prefixed named kebab-case to camelCase', (t) => {
   const plugin = fp((fastify, opts, next) => {
     next()
   }, {
@@ -84,7 +84,7 @@ test('from @-prefixed named kebab-case to camelCase', async (t) => {
   t.assert.strictEqual(plugin.helloMyWorld, plugin)
 })
 
-test('from kebab-case to camelCase multiple words', async (t) => {
+test('from kebab-case to camelCase multiple words', (t) => {
   const plugin = fp((fastify, opts, next) => {
     next()
   }, {
@@ -94,7 +94,7 @@ test('from kebab-case to camelCase multiple words', async (t) => {
   t.assert.strictEqual(plugin.helloLongWorld, plugin)
 })
 
-test('from kebab-case to camelCase multiple words does not override', async (t) => {
+test('from kebab-case to camelCase multiple words does not override', (t) => {
   const fn = (fastify, opts, next) => {
     next()
   }

--- a/test/bundlers.test.js
+++ b/test/bundlers.test.js
@@ -3,7 +3,7 @@
 const { test } = require('node:test')
 const fp = require('../plugin')
 
-test('webpack removes require.main.filename', async (t) => {
+test('webpack removes require.main.filename', t => {
   const filename = require.main.filename
   const info = console.info
   t.after(() => {

--- a/test/checkVersion.test.js
+++ b/test/checkVersion.test.js
@@ -1,17 +1,17 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const fp = require('../plugin')
 
 test('checkVersion having require.main.filename', (t) => {
   const info = console.info
-  t.ok(require.main.filename)
-  t.teardown(() => {
+  t.assert.ok(require.main.filename)
+  t.after(() => {
     console.info = info
   })
 
   console.info = function (msg) {
-    t.fail('logged: ' + msg)
+    t.assert.fail('logged: ' + msg)
   }
 
   fp((fastify, opts, next) => {
@@ -19,14 +19,12 @@ test('checkVersion having require.main.filename', (t) => {
   }, {
     fastify: '^5.0.0'
   })
-
-  t.end()
 })
 
 test('checkVersion having no require.main.filename but process.argv[1]', (t) => {
   const filename = require.main.filename
   const info = console.info
-  t.teardown(() => {
+  t.after(() => {
     require.main.filename = filename
     console.info = info
   })
@@ -34,7 +32,7 @@ test('checkVersion having no require.main.filename but process.argv[1]', (t) => 
   require.main.filename = null
 
   console.info = function (msg) {
-    t.fail('logged: ' + msg)
+    t.assert.fail('logged: ' + msg)
   }
 
   fp((fastify, opts, next) => {
@@ -42,15 +40,13 @@ test('checkVersion having no require.main.filename but process.argv[1]', (t) => 
   }, {
     fastify: '^5.0.0'
   })
-
-  t.end()
 })
 
 test('checkVersion having no require.main.filename and no process.argv[1]', (t) => {
   const filename = require.main.filename
   const argv = process.argv
   const info = console.info
-  t.teardown(() => {
+  t.after(() => {
     require.main.filename = filename
     process.argv = argv
     console.info = info
@@ -60,7 +56,7 @@ test('checkVersion having no require.main.filename and no process.argv[1]', (t) 
   process.argv[1] = null
 
   console.info = function (msg) {
-    t.fail('logged: ' + msg)
+    t.assert.fail('logged: ' + msg)
   }
 
   fp((fastify, opts, next) => {
@@ -68,6 +64,4 @@ test('checkVersion having no require.main.filename and no process.argv[1]', (t) 
   }, {
     fastify: '^5.0.0'
   })
-
-  t.end()
 })

--- a/test/composite.test.js
+++ b/test/composite.test.js
@@ -1,16 +1,14 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const fp = require('../plugin')
 
-test('anonymous function should be named composite.test0', t => {
+test('anonymous function should be named composite.test0', async (t) => {
   t.plan(2)
-
   const fn = fp((fastify, opts, next) => {
     next()
   })
 
-  t.equal(fn[Symbol.for('plugin-meta')].name, 'composite.test-auto-0')
-  t.equal(fn[Symbol.for('fastify.display-name')], 'composite.test-auto-0')
+  t.assert.strictEqual(fn[Symbol.for('plugin-meta')].name, 'composite.test-auto-0')
+  t.assert.strictEqual(fn[Symbol.for('fastify.display-name')], 'composite.test-auto-0')
 })

--- a/test/composite.test.js
+++ b/test/composite.test.js
@@ -3,7 +3,7 @@
 const { test } = require('node:test')
 const fp = require('../plugin')
 
-test('anonymous function should be named composite.test0', async (t) => {
+test('anonymous function should be named composite.test0', (t) => {
   t.plan(2)
   const fn = fp((fastify, opts, next) => {
     next()

--- a/test/esm/esm.mjs
+++ b/test/esm/esm.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test'
 import fp from '../../plugin.js'
 
-test('esm base support', async (t) => {
+test('esm base support', (t) => {
   fp((fastify, opts, next) => {
     next()
   }, {

--- a/test/esm/esm.mjs
+++ b/test/esm/esm.mjs
@@ -1,13 +1,11 @@
-import t from 'tap'
-
+import { test } from 'node:test'
 import fp from '../../plugin.js'
 
-t.test('esm base support', async t => {
+test('esm base support', async (t) => {
   fp((fastify, opts, next) => {
     next()
   }, {
     fastify: '^5.0.0'
   })
-
-  t.end()
+  t.assert.ok(true, 'fp function called without throwing an error')
 })

--- a/test/extractPluginName.test.js
+++ b/test/extractPluginName.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
 const extractPluginName = require('../lib/getPluginName').extractPluginName
 
 const winStack = `Error: anonymous function
@@ -41,8 +41,9 @@ at TAP.test (/home/leonardo/desktop/fastify-plugin/node_modules/tap/lib/test.js:
 
 const anonymousStack = 'Unable to parse this'
 
-t.plan(3)
-
-t.equal(extractPluginName(winStack), 'hello.test')
-t.equal(extractPluginName(nixStack), 'this.is.a.test')
-t.equal(extractPluginName(anonymousStack), 'anonymous')
+test('extractPluginName tests', async (t) => {
+  t.plan(3)
+  t.assert.strictEqual(extractPluginName(winStack), 'hello.test')
+  t.assert.strictEqual(extractPluginName(nixStack), 'this.is.a.test')
+  t.assert.strictEqual(extractPluginName(anonymousStack), 'anonymous')
+})

--- a/test/extractPluginName.test.js
+++ b/test/extractPluginName.test.js
@@ -41,7 +41,7 @@ at TAP.test (/home/leonardo/desktop/fastify-plugin/node_modules/tap/lib/test.js:
 
 const anonymousStack = 'Unable to parse this'
 
-test('extractPluginName tests', async (t) => {
+test('extractPluginName tests', (t) => {
   t.plan(3)
   t.assert.strictEqual(extractPluginName(winStack), 'hello.test')
   t.assert.strictEqual(extractPluginName(nixStack), 'this.is.a.test')

--- a/test/mu1tip1e.composite.test.js
+++ b/test/mu1tip1e.composite.test.js
@@ -1,16 +1,15 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const fp = require('../plugin')
 
-test('anonymous function should be named mu1tip1e.composite.test', t => {
+test('anonymous function should be named mu1tip1e.composite.test', async (t) => {
   t.plan(2)
 
   const fn = fp((fastify, opts, next) => {
     next()
   })
 
-  t.equal(fn[Symbol.for('plugin-meta')].name, 'mu1tip1e.composite.test-auto-0')
-  t.equal(fn[Symbol.for('fastify.display-name')], 'mu1tip1e.composite.test-auto-0')
+  t.assert.strictEqual(fn[Symbol.for('plugin-meta')].name, 'mu1tip1e.composite.test-auto-0')
+  t.assert.strictEqual(fn[Symbol.for('fastify.display-name')], 'mu1tip1e.composite.test-auto-0')
 })

--- a/test/mu1tip1e.composite.test.js
+++ b/test/mu1tip1e.composite.test.js
@@ -3,7 +3,7 @@
 const { test } = require('node:test')
 const fp = require('../plugin')
 
-test('anonymous function should be named mu1tip1e.composite.test', async (t) => {
+test('anonymous function should be named mu1tip1e.composite.test', (t) => {
   t.plan(2)
 
   const fn = fp((fastify, opts, next) => {

--- a/test/test.js
+++ b/test/test.js
@@ -7,12 +7,12 @@ const Fastify = require('fastify')
 
 const pkg = require('../package.json')
 
-test('fastify-plugin is a function', async (t) => {
+test('fastify-plugin is a function', (t) => {
   t.plan(1)
   t.assert.ok(typeof fp === 'function')
 })
 
-test('should return the function with the skip-override Symbol', async (t) => {
+test('should return the function with the skip-override Symbol', (t) => {
   t.plan(1)
 
   function plugin (fastify, opts, next) {
@@ -23,7 +23,7 @@ test('should return the function with the skip-override Symbol', async (t) => {
   t.assert.ok(plugin[Symbol.for('skip-override')])
 })
 
-test('should support "default" function from babel module', async (t) => {
+test('should support "default" function from babel module', (t) => {
   t.plan(1)
 
   const plugin = {
@@ -38,7 +38,7 @@ test('should support "default" function from babel module', async (t) => {
   }
 })
 
-test('should throw if the plugin is not a function', async (t) => {
+test('should throw if the plugin is not a function', (t) => {
   t.plan(1)
 
   try {
@@ -49,7 +49,7 @@ test('should throw if the plugin is not a function', async (t) => {
   }
 })
 
-test('should check the fastify version', async (t) => {
+test('should check the fastify version', (t) => {
   t.plan(1)
 
   function plugin (fastify, opts, next) {
@@ -64,7 +64,7 @@ test('should check the fastify version', async (t) => {
   }
 })
 
-test('should check the fastify version', async (t) => {
+test('should check the fastify version', (t) => {
   t.plan(1)
 
   function plugin (fastify, opts, next) {
@@ -79,7 +79,7 @@ test('should check the fastify version', async (t) => {
   }
 })
 
-test('the options object should be an object', async (t) => {
+test('the options object should be an object', (t) => {
   t.plan(2)
 
   try {
@@ -97,7 +97,7 @@ test('the options object should be an object', async (t) => {
   }
 })
 
-test('should throw if the version number is not a string', async (t) => {
+test('should throw if the version number is not a string', (t) => {
   t.plan(1)
 
   try {
@@ -108,7 +108,7 @@ test('should throw if the version number is not a string', async (t) => {
   }
 })
 
-test('Should accept an option object', async (t) => {
+test('Should accept an option object', (t) => {
   t.plan(2)
 
   const opts = { hello: 'world' }
@@ -123,7 +123,7 @@ test('Should accept an option object', async (t) => {
   t.assert.deepStrictEqual(plugin[Symbol.for('plugin-meta')], opts, 'plugin-meta should match opts')
 })
 
-test('Should accept an option object and checks the version', async (t) => {
+test('Should accept an option object and checks the version', (t) => {
   t.plan(2)
 
   const opts = { hello: 'world', fastify: '>=0.10.0' }
@@ -137,7 +137,7 @@ test('Should accept an option object and checks the version', async (t) => {
   t.assert.deepStrictEqual(plugin[Symbol.for('plugin-meta')], opts)
 })
 
-test('should set anonymous function name to file it was called from with a counter', async (t) => {
+test('should set anonymous function name to file it was called from with a counter', (t) => {
   const fp = proxyquire('../plugin.js', { stubs: {} })
 
   const fn = fp((fastify, opts, next) => {
@@ -155,7 +155,7 @@ test('should set anonymous function name to file it was called from with a count
   t.assert.strictEqual(fn2[Symbol.for('fastify.display-name')], 'test-auto-1')
 })
 
-test('should set function name if Error.stackTraceLimit is set to 0', async (t) => {
+test('should set function name if Error.stackTraceLimit is set to 0', (t) => {
   const stackTraceLimit = Error.stackTraceLimit = 0
 
   const fp = proxyquire('../plugin.js', { stubs: {} })
@@ -177,7 +177,7 @@ test('should set function name if Error.stackTraceLimit is set to 0', async (t) 
   Error.stackTraceLimit = stackTraceLimit
 })
 
-test('should set display-name to meta name', async (t) => {
+test('should set display-name to meta name', (t) => {
   t.plan(2)
 
   const functionName = 'superDuperSpecialFunction'
@@ -190,7 +190,7 @@ test('should set display-name to meta name', async (t) => {
   t.assert.strictEqual(fn[Symbol.for('fastify.display-name')], functionName)
 })
 
-test('should preserve fastify version in meta', async (t) => {
+test('should preserve fastify version in meta', (t) => {
   t.plan(1)
 
   const opts = { hello: 'world', fastify: '>=0.10.0' }
@@ -215,12 +215,7 @@ test('should check fastify dependency graph - plugin', async (t) => {
     dependencies: ['plugin1-name', 'plugin2-name']
   }))
 
-  try {
-    await fastify.ready()
-    t.assert.fail()
-  } catch (err) {
-    t.assert.strictEqual(err.message, "The dependency 'plugin2-name' of plugin 'test' is not registered")
-  }
+  await t.assert.rejects(fastify.ready(), { message: "The dependency 'plugin2-name' of plugin 'test' is not registered" })
 })
 
 test('should check fastify dependency graph - decorate', async (t) => {
@@ -238,12 +233,7 @@ test('should check fastify dependency graph - decorate', async (t) => {
     decorators: { fastify: ['plugin1', 'plugin2'] }
   }))
 
-  try {
-    await fastify.ready()
-    t.assert.fail()
-  } catch (err) {
-    t.assert.strictEqual(err.message, "The decorator 'plugin2' required by 'test' is not present in Fastify")
-  }
+  await t.assert.rejects(fastify.ready(), { message: "The decorator 'plugin2' required by 'test' is not present in Fastify" })
 })
 
 test('should check fastify dependency graph - decorateReply', async (t) => {
@@ -261,11 +251,7 @@ test('should check fastify dependency graph - decorateReply', async (t) => {
     decorators: { reply: ['plugin1', 'plugin2'] }
   }))
 
-  try {
-    await fastify.ready()
-  } catch (err) {
-    t.assert.strictEqual(err.message, "The decorator 'plugin2' required by 'test' is not present in Reply")
-  }
+  await t.assert.rejects(fastify.ready(), { message: "The decorator 'plugin2' required by 'test' is not present in Reply" })
 })
 
 test('should accept an option to encapsulate', async (t) => {
@@ -296,11 +282,8 @@ test('should accept an option to encapsulate', async (t) => {
     encapsulate: true
   }))
 
-  try {
-    await fastify.ready()
-  } catch (err) {
-    t.assert.ifError(err)
-  }
+  await fastify.ready()
+
   t.assert.ok(fastify.hasDecorator('accessible'))
   t.assert.ok(fastify.hasDecorator('alsoAccessible'))
   t.assert.ok(!fastify.hasDecorator('encapsulated'))
@@ -316,14 +299,7 @@ test('should check dependencies when encapsulated', async (t) => {
     encapsulate: true
   }))
 
-  try {
-    await fastify.ready()
-  } catch (err) {
-    t.assert.strictEqual(err.message, "The dependency 'missing-dependency-name' of plugin 'test' is not registered")
-  }
-  // fastify.ready(err => {
-  //   t.equal(err.message, "The dependency 'missing-dependency-name' of plugin 'test' is not registered")
-  // })
+  await t.assert.rejects(fastify.ready(), { message: "The dependency 'missing-dependency-name' of plugin 'test' is not registered" })
 })
 
 test(
@@ -339,11 +315,7 @@ test(
       encapsulate: true
     }))
 
-    try {
-      await fastify.ready()
-    } catch (err) {
-      t.assert.match(err.message, /fastify-plugin: test - expected '<=2.10.0' fastify version, '\d.\d+.\d+' is installed/)
-    }
+    await t.assert.rejects(fastify.ready(), { message: /fastify-plugin: test - expected '<=2.10.0' fastify version, '\d.\d+.\d+' is installed/ })
   }
 )
 
@@ -360,11 +332,7 @@ test('should check decorators when encapsulated', async (t) => {
     decorators: { fastify: ['plugin1', 'plugin2'] }
   }))
 
-  try {
-    await fastify.ready()
-  } catch (err) {
-    t.assert.strictEqual(err.message, "The decorator 'plugin2' required by 'test' is not present in Fastify")
-  }
+  await t.assert.rejects(fastify.ready(), { message: "The decorator 'plugin2' required by 'test' is not present in Fastify" })
 })
 
 test('plugin name when encapsulated', async (t) => {

--- a/test/test.js
+++ b/test/test.js
@@ -1,19 +1,18 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
 const proxyquire = require('proxyquire')
-const test = t.test
 const fp = require('../plugin')
 const Fastify = require('fastify')
 
 const pkg = require('../package.json')
 
-test('fastify-plugin is a function', t => {
+test('fastify-plugin is a function', async (t) => {
   t.plan(1)
-  t.type(fp, 'function')
+  t.assert.ok(typeof fp === 'function')
 })
 
-test('should return the function with the skip-override Symbol', t => {
+test('should return the function with the skip-override Symbol', async (t) => {
   t.plan(1)
 
   function plugin (fastify, opts, next) {
@@ -21,10 +20,10 @@ test('should return the function with the skip-override Symbol', t => {
   }
 
   fp(plugin)
-  t.ok(plugin[Symbol.for('skip-override')])
+  t.assert.ok(plugin[Symbol.for('skip-override')])
 })
 
-test('should support "default" function from babel module', t => {
+test('should support "default" function from babel module', async (t) => {
   t.plan(1)
 
   const plugin = {
@@ -33,24 +32,24 @@ test('should support "default" function from babel module', t => {
 
   try {
     fp(plugin)
-    t.pass()
+    t.assert.ok(true)
   } catch (e) {
-    t.equal(e.message, 'fastify-plugin expects a function, instead got a \'object\'')
+    t.assert.strictEqual(e.message, 'fastify-plugin expects a function, instead got a \'object\'')
   }
 })
 
-test('should throw if the plugin is not a function', t => {
+test('should throw if the plugin is not a function', async (t) => {
   t.plan(1)
 
   try {
     fp('plugin')
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.equal(e.message, 'fastify-plugin expects a function, instead got a \'string\'')
+    t.assert.strictEqual(e.message, 'fastify-plugin expects a function, instead got a \'string\'')
   }
 })
 
-test('should check the fastify version', t => {
+test('should check the fastify version', async (t) => {
   t.plan(1)
 
   function plugin (fastify, opts, next) {
@@ -59,13 +58,13 @@ test('should check the fastify version', t => {
 
   try {
     fp(plugin, { fastify: '>=0.10.0' })
-    t.pass()
+    t.assert.ok(true)
   } catch (e) {
-    t.fail()
+    t.assert.fail()
   }
 })
 
-test('should check the fastify version', t => {
+test('should check the fastify version', async (t) => {
   t.plan(1)
 
   function plugin (fastify, opts, next) {
@@ -74,42 +73,42 @@ test('should check the fastify version', t => {
 
   try {
     fp(plugin, '>=0.10.0')
-    t.pass()
+    t.assert.ok(true)
   } catch (e) {
-    t.fail()
+    t.assert.fail()
   }
 })
 
-test('the options object should be an object', t => {
+test('the options object should be an object', async (t) => {
   t.plan(2)
 
   try {
     fp(() => { }, null)
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.equal(e.message, 'The options object should be an object')
+    t.assert.strictEqual(e.message, 'The options object should be an object')
   }
 
   try {
     fp(() => { }, [])
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.equal(e.message, 'The options object should be an object')
+    t.assert.strictEqual(e.message, 'The options object should be an object')
   }
 })
 
-test('should throw if the version number is not a string', t => {
+test('should throw if the version number is not a string', async (t) => {
   t.plan(1)
 
   try {
     fp(() => { }, { fastify: 12 })
-    t.fail()
+    t.assert.fail()
   } catch (e) {
-    t.equal(e.message, 'fastify-plugin expects a version string, instead got \'number\'')
+    t.assert.strictEqual(e.message, 'fastify-plugin expects a version string, instead got \'number\'')
   }
 })
 
-test('Should accept an option object', t => {
+test('Should accept an option object', async (t) => {
   t.plan(2)
 
   const opts = { hello: 'world' }
@@ -119,11 +118,12 @@ test('Should accept an option object', t => {
   }
 
   fp(plugin, opts)
-  t.ok(plugin[Symbol.for('skip-override')])
-  t.same(plugin[Symbol.for('plugin-meta')], opts)
+
+  t.assert.ok(plugin[Symbol.for('skip-override')], 'skip-override symbol should be present')
+  t.assert.deepStrictEqual(plugin[Symbol.for('plugin-meta')], opts, 'plugin-meta should match opts')
 })
 
-test('Should accept an option object and checks the version', t => {
+test('Should accept an option object and checks the version', async (t) => {
   t.plan(2)
 
   const opts = { hello: 'world', fastify: '>=0.10.0' }
@@ -133,31 +133,29 @@ test('Should accept an option object and checks the version', t => {
   }
 
   fp(plugin, opts)
-  t.ok(plugin[Symbol.for('skip-override')])
-  t.same(plugin[Symbol.for('plugin-meta')], opts)
+  t.assert.ok(plugin[Symbol.for('skip-override')])
+  t.assert.deepStrictEqual(plugin[Symbol.for('plugin-meta')], opts)
 })
 
-test('should set anonymous function name to file it was called from with a counter', t => {
+test('should set anonymous function name to file it was called from with a counter', async (t) => {
   const fp = proxyquire('../plugin.js', { stubs: {} })
 
   const fn = fp((fastify, opts, next) => {
     next()
   })
 
-  t.equal(fn[Symbol.for('plugin-meta')].name, 'test-auto-0')
-  t.equal(fn[Symbol.for('fastify.display-name')], 'test-auto-0')
+  t.assert.strictEqual(fn[Symbol.for('plugin-meta')].name, 'test-auto-0')
+  t.assert.strictEqual(fn[Symbol.for('fastify.display-name')], 'test-auto-0')
 
   const fn2 = fp((fastify, opts, next) => {
     next()
   })
 
-  t.equal(fn2[Symbol.for('plugin-meta')].name, 'test-auto-1')
-  t.equal(fn2[Symbol.for('fastify.display-name')], 'test-auto-1')
-
-  t.end()
+  t.assert.strictEqual(fn2[Symbol.for('plugin-meta')].name, 'test-auto-1')
+  t.assert.strictEqual(fn2[Symbol.for('fastify.display-name')], 'test-auto-1')
 })
 
-test('should set function name if Error.stackTraceLimit is set to 0', t => {
+test('should set function name if Error.stackTraceLimit is set to 0', async (t) => {
   const stackTraceLimit = Error.stackTraceLimit = 0
 
   const fp = proxyquire('../plugin.js', { stubs: {} })
@@ -166,21 +164,20 @@ test('should set function name if Error.stackTraceLimit is set to 0', t => {
     next()
   })
 
-  t.equal(fn[Symbol.for('plugin-meta')].name, 'test-auto-0')
-  t.equal(fn[Symbol.for('fastify.display-name')], 'test-auto-0')
+  t.assert.strictEqual(fn[Symbol.for('plugin-meta')].name, 'test-auto-0')
+  t.assert.strictEqual(fn[Symbol.for('fastify.display-name')], 'test-auto-0')
 
   const fn2 = fp((fastify, opts, next) => {
     next()
   })
 
-  t.equal(fn2[Symbol.for('plugin-meta')].name, 'test-auto-1')
-  t.equal(fn2[Symbol.for('fastify.display-name')], 'test-auto-1')
+  t.assert.strictEqual(fn2[Symbol.for('plugin-meta')].name, 'test-auto-1')
+  t.assert.strictEqual(fn2[Symbol.for('fastify.display-name')], 'test-auto-1')
 
   Error.stackTraceLimit = stackTraceLimit
-  t.end()
 })
 
-test('should set display-name to meta name', t => {
+test('should set display-name to meta name', async (t) => {
   t.plan(2)
 
   const functionName = 'superDuperSpecialFunction'
@@ -189,21 +186,21 @@ test('should set display-name to meta name', t => {
     name: functionName
   })
 
-  t.equal(fn[Symbol.for('plugin-meta')].name, functionName)
-  t.equal(fn[Symbol.for('fastify.display-name')], functionName)
+  t.assert.strictEqual(fn[Symbol.for('plugin-meta')].name, functionName)
+  t.assert.strictEqual(fn[Symbol.for('fastify.display-name')], functionName)
 })
 
-test('should preserve fastify version in meta', t => {
+test('should preserve fastify version in meta', async (t) => {
   t.plan(1)
 
   const opts = { hello: 'world', fastify: '>=0.10.0' }
 
   const fn = fp((fastify, opts, next) => next(), opts)
 
-  t.equal(fn[Symbol.for('plugin-meta')].fastify, '>=0.10.0')
+  t.assert.strictEqual(fn[Symbol.for('plugin-meta')].fastify, '>=0.10.0')
 })
 
-test('should check fastify dependency graph - plugin', t => {
+test('should check fastify dependency graph - plugin', async (t) => {
   t.plan(1)
   const fastify = Fastify()
 
@@ -218,12 +215,15 @@ test('should check fastify dependency graph - plugin', t => {
     dependencies: ['plugin1-name', 'plugin2-name']
   }))
 
-  fastify.ready(err => {
-    t.equal(err.message, "The dependency 'plugin2-name' of plugin 'test' is not registered")
-  })
+  try {
+    await fastify.ready()
+    t.assert.fail()
+  } catch (err) {
+    t.assert.strictEqual(err.message, "The dependency 'plugin2-name' of plugin 'test' is not registered")
+  }
 })
 
-test('should check fastify dependency graph - decorate', t => {
+test('should check fastify dependency graph - decorate', async (t) => {
   t.plan(1)
   const fastify = Fastify()
 
@@ -238,12 +238,15 @@ test('should check fastify dependency graph - decorate', t => {
     decorators: { fastify: ['plugin1', 'plugin2'] }
   }))
 
-  fastify.ready(err => {
-    t.equal(err.message, "The decorator 'plugin2' required by 'test' is not present in Fastify")
-  })
+  try {
+    await fastify.ready()
+    t.assert.fail()
+  } catch (err) {
+    t.assert.strictEqual(err.message, "The decorator 'plugin2' required by 'test' is not present in Fastify")
+  }
 })
 
-test('should check fastify dependency graph - decorateReply', t => {
+test('should check fastify dependency graph - decorateReply', async (t) => {
   t.plan(1)
   const fastify = Fastify()
 
@@ -258,13 +261,16 @@ test('should check fastify dependency graph - decorateReply', t => {
     decorators: { reply: ['plugin1', 'plugin2'] }
   }))
 
-  fastify.ready(err => {
-    t.equal(err.message, "The decorator 'plugin2' required by 'test' is not present in Reply")
-  })
+  try {
+    await fastify.ready()
+  } catch (err) {
+    t.assert.strictEqual(err.message, "The decorator 'plugin2' required by 'test' is not present in Reply")
+  }
 })
 
-test('should accept an option to encapsulate', t => {
-  t.plan(4)
+test('should accept an option to encapsulate', async (t) => {
+  t.plan(3)
+
   const fastify = Fastify()
 
   fastify.register(fp((fastify, opts, next) => {
@@ -290,15 +296,17 @@ test('should accept an option to encapsulate', t => {
     encapsulate: true
   }))
 
-  fastify.ready(err => {
-    t.error(err)
-    t.ok(fastify.hasDecorator('accessible'))
-    t.ok(fastify.hasDecorator('alsoAccessible'))
-    t.notOk(fastify.hasDecorator('encapsulated'))
-  })
+  try {
+    await fastify.ready()
+  } catch (err) {
+    t.assert.ifError(err)
+  }
+  t.assert.ok(fastify.hasDecorator('accessible'))
+  t.assert.ok(fastify.hasDecorator('alsoAccessible'))
+  t.assert.ok(!fastify.hasDecorator('encapsulated'))
 })
 
-test('should check dependencies when encapsulated', t => {
+test('should check dependencies when encapsulated', async (t) => {
   t.plan(1)
   const fastify = Fastify()
 
@@ -308,15 +316,20 @@ test('should check dependencies when encapsulated', t => {
     encapsulate: true
   }))
 
-  fastify.ready(err => {
-    t.equal(err.message, "The dependency 'missing-dependency-name' of plugin 'test' is not registered")
-  })
+  try {
+    await fastify.ready()
+  } catch (err) {
+    t.assert.strictEqual(err.message, "The dependency 'missing-dependency-name' of plugin 'test' is not registered")
+  }
+  // fastify.ready(err => {
+  //   t.equal(err.message, "The dependency 'missing-dependency-name' of plugin 'test' is not registered")
+  // })
 })
 
 test(
   'should check version when encapsulated',
   { skip: /\d-.+/.test(pkg.devDependencies.fastify) },
-  t => {
+  async (t) => {
     t.plan(1)
     const fastify = Fastify()
 
@@ -326,13 +339,15 @@ test(
       encapsulate: true
     }))
 
-    fastify.ready(err => {
-      t.match(err.message, /fastify-plugin: test - expected '<=2.10.0' fastify version, '\d.\d+.\d+' is installed/)
-    })
+    try {
+      await fastify.ready()
+    } catch (err) {
+      t.assert.match(err.message, /fastify-plugin: test - expected '<=2.10.0' fastify version, '\d.\d+.\d+' is installed/)
+    }
   }
 )
 
-test('should check decorators when encapsulated', t => {
+test('should check decorators when encapsulated', async (t) => {
   t.plan(1)
   const fastify = Fastify()
 
@@ -345,12 +360,15 @@ test('should check decorators when encapsulated', t => {
     decorators: { fastify: ['plugin1', 'plugin2'] }
   }))
 
-  fastify.ready(err => {
-    t.equal(err.message, "The decorator 'plugin2' required by 'test' is not present in Fastify")
-  })
+  try {
+    await fastify.ready()
+  } catch (err) {
+    t.assert.strictEqual(err.message, "The decorator 'plugin2' required by 'test' is not present in Fastify")
+  }
 })
 
-test('plugin name when encapsulated', async t => {
+test('plugin name when encapsulated', async (t) => {
+  t.plan(6)
   const fastify = Fastify()
 
   fastify.register(function plugin (instance, opts, next) {
@@ -371,7 +389,7 @@ test('plugin name when encapsulated', async t => {
     }))
 
     fastify.register(fp(function genericPlugin (fastify, opts, next) {
-      t.equal(fastify.pluginName, 'deep-deep', 'should be deep-deep')
+      t.assert.strictEqual(fastify.pluginName, 'deep-deep', 'should be deep-deep')
 
       fastify.register(fp(getFn('deep-deep-deep'), {
         fastify: '5.x',
@@ -403,7 +421,7 @@ test('plugin name when encapsulated', async t => {
 
   function getFn (expectedName) {
     return function genericPlugin (fastify, opts, next) {
-      t.equal(fastify.pluginName, expectedName, `should be ${expectedName}`)
+      t.assert.strictEqual(fastify.pluginName, expectedName, `should be ${expectedName}`)
       next()
     }
   }

--- a/test/toCamelCase.test.js
+++ b/test/toCamelCase.test.js
@@ -1,24 +1,24 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const toCamelCase = require('../lib/toCamelCase')
 
-test('from kebab-case to camelCase', (t) => {
+test('from kebab-case to camelCase', async (t) => {
   t.plan(1)
-  t.equal(toCamelCase('hello-world'), 'helloWorld')
+  t.assert.strictEqual(toCamelCase('hello-world'), 'helloWorld')
 })
 
 test('from @-prefixed named imports', (t) => {
   t.plan(1)
-  t.equal(toCamelCase('@hello/world'), 'helloWorld')
+  t.assert.strictEqual(toCamelCase('@hello/world'), 'helloWorld')
 })
 
 test('from @-prefixed named kebab-case to camelCase', (t) => {
   t.plan(1)
-  t.equal(toCamelCase('@hello/my-world'), 'helloMyWorld')
+  t.assert.strictEqual(toCamelCase('@hello/my-world'), 'helloMyWorld')
 })
 
 test('from kebab-case to camelCase multiple words', (t) => {
   t.plan(1)
-  t.equal(toCamelCase('hello-long-world'), 'helloLongWorld')
+  t.assert.strictEqual(toCamelCase('hello-long-world'), 'helloLongWorld')
 })

--- a/test/toCamelCase.test.js
+++ b/test/toCamelCase.test.js
@@ -3,7 +3,7 @@
 const { test } = require('node:test')
 const toCamelCase = require('../lib/toCamelCase')
 
-test('from kebab-case to camelCase', async (t) => {
+test('from kebab-case to camelCase', (t) => {
   t.plan(1)
   t.assert.strictEqual(toCamelCase('hello-world'), 'helloWorld')
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

This PR replaces tap with node:test for testing and adds c8 for coverage.

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
