### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@fastify/type-provider-typebox": "^5.0.0-pre.fv5.1",
     "@types/node": "^22.0.0",
     "c8": "^10.1.2",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "neostandard": "^0.11.9",
     "proxyquire": "^2.1.3",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.