### PR TITLE
refactor: prefix unused params with underscores

### DIFF
--- a/test/bundlers.test.js
+++ b/test/bundlers.test.js
@@ -17,7 +17,7 @@ test('webpack removes require.main.filename', t => {
     t.assert.fail('logged: ' + msg)
   }
 
-  fp((fastify, opts, next) => {
+  fp((_fastify, _opts, next) => {
     next()
   }, {
     fastify: '^5.0.0'
@@ -25,7 +25,7 @@ test('webpack removes require.main.filename', t => {
 })
 
 test('support faux modules', (t) => {
-  const plugin = fp((fastify, opts, next) => {
+  const plugin = fp((_fastify, _opts, next) => {
     next()
   })
 
@@ -34,7 +34,7 @@ test('support faux modules', (t) => {
 
 test('support faux modules does not override existing default field in babel module', (t) => {
   const module = {
-    default: (fastify, opts, next) => next()
+    default: (_fastify, _opts, next) => next()
   }
 
   module.default.default = 'Existing default field'
@@ -45,7 +45,7 @@ test('support faux modules does not override existing default field in babel mod
 })
 
 test('support ts named imports', (t) => {
-  const plugin = fp((fastify, opts, next) => {
+  const plugin = fp((_fastify, _opts, next) => {
     next()
   }, {
     name: 'hello'
@@ -55,7 +55,7 @@ test('support ts named imports', (t) => {
 })
 
 test('from kebab-case to camelCase', (t) => {
-  const plugin = fp((fastify, opts, next) => {
+  const plugin = fp((_fastify, _opts, next) => {
     next()
   }, {
     name: 'hello-world'
@@ -65,7 +65,7 @@ test('from kebab-case to camelCase', (t) => {
 })
 
 test('from @-prefixed named imports', (t) => {
-  const plugin = fp((fastify, opts, next) => {
+  const plugin = fp((_fastify, _opts, next) => {
     next()
   }, {
     name: '@hello/world'
@@ -75,7 +75,7 @@ test('from @-prefixed named imports', (t) => {
 })
 
 test('from @-prefixed named kebab-case to camelCase', (t) => {
-  const plugin = fp((fastify, opts, next) => {
+  const plugin = fp((_fastify, _opts, next) => {
     next()
   }, {
     name: '@hello/my-world'
@@ -85,7 +85,7 @@ test('from @-prefixed named kebab-case to camelCase', (t) => {
 })
 
 test('from kebab-case to camelCase multiple words', (t) => {
-  const plugin = fp((fastify, opts, next) => {
+  const plugin = fp((_fastify, _opts, next) => {
     next()
   }, {
     name: 'hello-long-world'
@@ -95,7 +95,7 @@ test('from kebab-case to camelCase multiple words', (t) => {
 })
 
 test('from kebab-case to camelCase multiple words does not override', (t) => {
-  const fn = (fastify, opts, next) => {
+  const fn = (_fastify, _opts, next) => {
     next()
   }
 

--- a/test/checkVersion.test.js
+++ b/test/checkVersion.test.js
@@ -14,7 +14,7 @@ test('checkVersion having require.main.filename', (t) => {
     t.assert.fail('logged: ' + msg)
   }
 
-  fp((fastify, opts, next) => {
+  fp((_fastify, _opts, next) => {
     next()
   }, {
     fastify: '^5.0.0'
@@ -35,7 +35,7 @@ test('checkVersion having no require.main.filename but process.argv[1]', (t) => 
     t.assert.fail('logged: ' + msg)
   }
 
-  fp((fastify, opts, next) => {
+  fp((_fastify, _opts, next) => {
     next()
   }, {
     fastify: '^5.0.0'
@@ -59,7 +59,7 @@ test('checkVersion having no require.main.filename and no process.argv[1]', (t) 
     t.assert.fail('logged: ' + msg)
   }
 
-  fp((fastify, opts, next) => {
+  fp((_fastify, _opts, next) => {
     next()
   }, {
     fastify: '^5.0.0'

--- a/test/composite.test.js
+++ b/test/composite.test.js
@@ -5,7 +5,7 @@ const fp = require('../plugin')
 
 test('anonymous function should be named composite.test0', (t) => {
   t.plan(2)
-  const fn = fp((fastify, opts, next) => {
+  const fn = fp((_fastify, _opts, next) => {
     next()
   })
 

--- a/test/esm/esm.mjs
+++ b/test/esm/esm.mjs
@@ -2,7 +2,7 @@ import { test } from 'node:test'
 import fp from '../../plugin.js'
 
 test('esm base support', (t) => {
-  fp((fastify, opts, next) => {
+  fp((_fastify, _opts, next) => {
     next()
   }, {
     fastify: '^5.0.0'

--- a/test/mu1tip1e.composite.test.js
+++ b/test/mu1tip1e.composite.test.js
@@ -6,7 +6,7 @@ const fp = require('../plugin')
 test('anonymous function should be named mu1tip1e.composite.test', (t) => {
   t.plan(2)
 
-  const fn = fp((fastify, opts, next) => {
+  const fn = fp((_fastify, _opts, next) => {
     next()
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -15,7 +15,7 @@ test('fastify-plugin is a function', (t) => {
 test('should return the function with the skip-override Symbol', (t) => {
   t.plan(1)
 
-  function plugin (fastify, opts, next) {
+  function plugin (_fastify, _opts, next) {
     next()
   }
 
@@ -52,14 +52,14 @@ test('should throw if the plugin is not a function', (t) => {
 test('should check the fastify version', (t) => {
   t.plan(1)
 
-  function plugin (fastify, opts, next) {
+  function plugin (_fastify, _opts, next) {
     next()
   }
 
   try {
     fp(plugin, { fastify: '>=0.10.0' })
     t.assert.ok(true)
-  } catch (e) {
+  } catch {
     t.assert.fail()
   }
 })
@@ -67,14 +67,14 @@ test('should check the fastify version', (t) => {
 test('should check the fastify version', (t) => {
   t.plan(1)
 
-  function plugin (fastify, opts, next) {
+  function plugin (_fastify, _opts, next) {
     next()
   }
 
   try {
     fp(plugin, '>=0.10.0')
     t.assert.ok(true)
-  } catch (e) {
+  } catch {
     t.assert.fail()
   }
 })
@@ -113,7 +113,7 @@ test('Should accept an option object', (t) => {
 
   const opts = { hello: 'world' }
 
-  function plugin (fastify, opts, next) {
+  function plugin (_fastify, _opts, next) {
     next()
   }
 
@@ -128,7 +128,7 @@ test('Should accept an option object and checks the version', (t) => {
 
   const opts = { hello: 'world', fastify: '>=0.10.0' }
 
-  function plugin (fastify, opts, next) {
+  function plugin (_fastify, _opts, next) {
     next()
   }
 
@@ -140,14 +140,14 @@ test('Should accept an option object and checks the version', (t) => {
 test('should set anonymous function name to file it was called from with a counter', (t) => {
   const fp = proxyquire('../plugin.js', { stubs: {} })
 
-  const fn = fp((fastify, opts, next) => {
+  const fn = fp((_fastify, _opts, next) => {
     next()
   })
 
   t.assert.strictEqual(fn[Symbol.for('plugin-meta')].name, 'test-auto-0')
   t.assert.strictEqual(fn[Symbol.for('fastify.display-name')], 'test-auto-0')
 
-  const fn2 = fp((fastify, opts, next) => {
+  const fn2 = fp((_fastify, _opts, next) => {
     next()
   })
 
@@ -160,14 +160,14 @@ test('should set function name if Error.stackTraceLimit is set to 0', (t) => {
 
   const fp = proxyquire('../plugin.js', { stubs: {} })
 
-  const fn = fp((fastify, opts, next) => {
+  const fn = fp((_fastify, _opts, next) => {
     next()
   })
 
   t.assert.strictEqual(fn[Symbol.for('plugin-meta')].name, 'test-auto-0')
   t.assert.strictEqual(fn[Symbol.for('fastify.display-name')], 'test-auto-0')
 
-  const fn2 = fp((fastify, opts, next) => {
+  const fn2 = fp((_fastify, _opts, next) => {
     next()
   })
 
@@ -182,7 +182,7 @@ test('should set display-name to meta name', (t) => {
 
   const functionName = 'superDuperSpecialFunction'
 
-  const fn = fp((fastify, opts, next) => next(), {
+  const fn = fp((_fastify, _opts, next) => next(), {
     name: functionName
   })
 
@@ -195,7 +195,7 @@ test('should preserve fastify version in meta', (t) => {
 
   const opts = { hello: 'world', fastify: '>=0.10.0' }
 
-  const fn = fp((fastify, opts, next) => next(), opts)
+  const fn = fp((_fastify, _opts, next) => next(), opts)
 
   t.assert.strictEqual(fn[Symbol.for('plugin-meta')].fastify, '>=0.10.0')
 })
@@ -204,12 +204,12 @@ test('should check fastify dependency graph - plugin', async (t) => {
   t.plan(1)
   const fastify = Fastify()
 
-  fastify.register(fp((fastify, opts, next) => next(), {
+  fastify.register(fp((_fastify, _opts, next) => next(), {
     fastify: '5.x',
     name: 'plugin1-name'
   }))
 
-  fastify.register(fp((fastify, opts, next) => next(), {
+  fastify.register(fp((_fastify, _opts, next) => next(), {
     fastify: '5.x',
     name: 'test',
     dependencies: ['plugin1-name', 'plugin2-name']
@@ -222,12 +222,12 @@ test('should check fastify dependency graph - decorate', async (t) => {
   t.plan(1)
   const fastify = Fastify()
 
-  fastify.decorate('plugin1', fp((fastify, opts, next) => next(), {
+  fastify.decorate('plugin1', fp((_fastify, _opts, next) => next(), {
     fastify: '5.x',
     name: 'plugin1-name'
   }))
 
-  fastify.register(fp((fastify, opts, next) => next(), {
+  fastify.register(fp((_fastify, _opts, next) => next(), {
     fastify: '5.x',
     name: 'test',
     decorators: { fastify: ['plugin1', 'plugin2'] }
@@ -240,12 +240,12 @@ test('should check fastify dependency graph - decorateReply', async (t) => {
   t.plan(1)
   const fastify = Fastify()
 
-  fastify.decorateReply('plugin1', fp((fastify, opts, next) => next(), {
+  fastify.decorateReply('plugin1', fp((_fastify, _opts, next) => next(), {
     fastify: '5.x',
     name: 'plugin1-name'
   }))
 
-  fastify.register(fp((fastify, opts, next) => next(), {
+  fastify.register(fp((_fastify, _opts, next) => next(), {
     fastify: '5.x',
     name: 'test',
     decorators: { reply: ['plugin1', 'plugin2'] }
@@ -259,14 +259,14 @@ test('should accept an option to encapsulate', async (t) => {
 
   const fastify = Fastify()
 
-  fastify.register(fp((fastify, opts, next) => {
+  fastify.register(fp((fastify, _opts, next) => {
     fastify.decorate('accessible', true)
     next()
   }, {
     name: 'accessible-plugin'
   }))
 
-  fastify.register(fp((fastify, opts, next) => {
+  fastify.register(fp((fastify, _opts, next) => {
     fastify.decorate('alsoAccessible', true)
     next()
   }, {
@@ -274,7 +274,7 @@ test('should accept an option to encapsulate', async (t) => {
     encapsulate: false
   }))
 
-  fastify.register(fp((fastify, opts, next) => {
+  fastify.register(fp((fastify, _opts, next) => {
     fastify.decorate('encapsulated', true)
     next()
   }, {
@@ -293,7 +293,7 @@ test('should check dependencies when encapsulated', async (t) => {
   t.plan(1)
   const fastify = Fastify()
 
-  fastify.register(fp((fastify, opts, next) => next(), {
+  fastify.register(fp((_fastify, _opts, next) => next(), {
     name: 'test',
     dependencies: ['missing-dependency-name'],
     encapsulate: true
@@ -309,7 +309,7 @@ test(
     t.plan(1)
     const fastify = Fastify()
 
-    fastify.register(fp((fastify, opts, next) => next(), {
+    fastify.register(fp((_fastify, _opts, next) => next(), {
       name: 'test',
       fastify: '<=2.10.0',
       encapsulate: true
@@ -325,7 +325,7 @@ test('should check decorators when encapsulated', async (t) => {
 
   fastify.decorate('plugin1', 'foo')
 
-  fastify.register(fp((fastify, opts, next) => next(), {
+  fastify.register(fp((_fastify, _opts, next) => next(), {
     fastify: '5.x',
     name: 'test',
     encapsulate: true,
@@ -339,7 +339,7 @@ test('plugin name when encapsulated', async (t) => {
   t.plan(6)
   const fastify = Fastify()
 
-  fastify.register(function plugin (instance, opts, next) {
+  fastify.register(function plugin (_instance, _opts, next) {
     next()
   })
 
@@ -349,14 +349,14 @@ test('plugin name when encapsulated', async (t) => {
     encapsulate: true
   }))
 
-  fastify.register(function plugin (fastify, opts, next) {
+  fastify.register(function plugin (fastify, _opts, next) {
     fastify.register(fp(getFn('deep'), {
       fastify: '5.x',
       name: 'deep',
       encapsulate: true
     }))
 
-    fastify.register(fp(function genericPlugin (fastify, opts, next) {
+    fastify.register(fp(function genericPlugin (fastify, _opts, next) {
       t.assert.strictEqual(fastify.pluginName, 'deep-deep', 'should be deep-deep')
 
       fastify.register(fp(getFn('deep-deep-deep'), {
@@ -388,7 +388,7 @@ test('plugin name when encapsulated', async (t) => {
   await fastify.ready()
 
   function getFn (expectedName) {
-    return function genericPlugin (fastify, opts, next) {
+    return function genericPlugin (fastify, _opts, next) {
       t.assert.strictEqual(fastify.pluginName, expectedName, `should be ${expectedName}`)
       next()
     }

--- a/types/plugin.test-d.ts
+++ b/types/plugin.test-d.ts
@@ -14,15 +14,15 @@ const testSymbol = Symbol('foobar')
 
 // Callback
 
-const pluginCallback: FastifyPluginCallback = (fastify, options, next) => { }
+const pluginCallback: FastifyPluginCallback = (_fastify, _options, _next) => { }
 expectType<FastifyPluginCallback>(fastifyPlugin(pluginCallback))
 
-const pluginCallbackWithTypes = (fastify: FastifyInstance, options: FastifyPluginOptions, next: (error?: FastifyError) => void): void => { }
+const pluginCallbackWithTypes = (_fastify: FastifyInstance, _options: FastifyPluginOptions, _next: (error?: FastifyError) => void): void => { }
 expectAssignable<FastifyPluginCallback>(fastifyPlugin(pluginCallbackWithTypes))
 expectNotType<any>(fastifyPlugin(pluginCallbackWithTypes))
 
-expectAssignable<FastifyPluginCallback>(fastifyPlugin((fastify: FastifyInstance, options: FastifyPluginOptions, next: (error?: FastifyError) => void): void => { }))
-expectNotType<any>(fastifyPlugin((fastify: FastifyInstance, options: FastifyPluginOptions, next: (error?: FastifyError) => void): void => { }))
+expectAssignable<FastifyPluginCallback>(fastifyPlugin((_fastify: FastifyInstance, _options: FastifyPluginOptions, _next: (error?: FastifyError) => void): void => { }))
+expectNotType<any>(fastifyPlugin((_fastify: FastifyInstance, _options: FastifyPluginOptions, _next: (error?: FastifyError) => void): void => { }))
 
 expectType<FastifyPluginCallback>(fastifyPlugin(pluginCallback, ''))
 expectType<FastifyPluginCallback>(fastifyPlugin(pluginCallback, {
@@ -37,31 +37,31 @@ expectType<FastifyPluginCallback>(fastifyPlugin(pluginCallback, {
   encapsulate: true
 }))
 
-const pluginCallbackWithOptions: FastifyPluginCallback<Options> = (fastify, options, next) => {
+const pluginCallbackWithOptions: FastifyPluginCallback<Options> = (_fastify, options, _next) => {
   expectType<string>(options.foo)
 }
 
 expectType<FastifyPluginCallback<Options>>(fastifyPlugin(pluginCallbackWithOptions))
 
-const pluginCallbackWithServer: FastifyPluginCallback<Options, Server> = (fastify, options, next) => {
+const pluginCallbackWithServer: FastifyPluginCallback<Options, Server> = (fastify, _options, _next) => {
   expectType<Server>(fastify.server)
 }
 
 expectType<FastifyPluginCallback<Options, Server>>(fastifyPlugin(pluginCallbackWithServer))
 
-const pluginCallbackWithTypeProvider: FastifyPluginCallback<Options, Server, TypeBoxTypeProvider> = (fastify, options, next) => { }
+const pluginCallbackWithTypeProvider: FastifyPluginCallback<Options, Server, TypeBoxTypeProvider> = (_fastify, _options, _next) => { }
 
 expectType<FastifyPluginCallback<Options, Server, TypeBoxTypeProvider>>(fastifyPlugin(pluginCallbackWithTypeProvider))
 
 // Async
 
-const pluginAsync: FastifyPluginAsync = async (fastify, options) => { }
+const pluginAsync: FastifyPluginAsync = async (_fastify, _options) => { }
 expectType<FastifyPluginAsync>(fastifyPlugin(pluginAsync))
 
-const pluginAsyncWithTypes = async (fastify: FastifyInstance, options: FastifyPluginOptions): Promise<void> => { }
+const pluginAsyncWithTypes = async (_fastify: FastifyInstance, _options: FastifyPluginOptions): Promise<void> => { }
 expectType<FastifyPluginAsync<FastifyPluginOptions, RawServerDefault, FastifyTypeProviderDefault>>(fastifyPlugin(pluginAsyncWithTypes))
 
-expectType<FastifyPluginAsync<FastifyPluginOptions, RawServerDefault, FastifyTypeProviderDefault>>(fastifyPlugin(async (fastify: FastifyInstance, options: FastifyPluginOptions): Promise<void> => { }))
+expectType<FastifyPluginAsync<FastifyPluginOptions, RawServerDefault, FastifyTypeProviderDefault>>(fastifyPlugin(async (_fastify: FastifyInstance, _options: FastifyPluginOptions): Promise<void> => { }))
 expectType<FastifyPluginAsync>(fastifyPlugin(pluginAsync, ''))
 expectType<FastifyPluginAsync>(fastifyPlugin(pluginAsync, {
   fastify: '',
@@ -75,19 +75,19 @@ expectType<FastifyPluginAsync>(fastifyPlugin(pluginAsync, {
   encapsulate: true
 }))
 
-const pluginAsyncWithOptions: FastifyPluginAsync<Options> = async (fastify, options) => {
+const pluginAsyncWithOptions: FastifyPluginAsync<Options> = async (_fastify, options) => {
   expectType<string>(options.foo)
 }
 
 expectType<FastifyPluginAsync<Options>>(fastifyPlugin(pluginAsyncWithOptions))
 
-const pluginAsyncWithServer: FastifyPluginAsync<Options, Server> = async (fastify, options) => {
+const pluginAsyncWithServer: FastifyPluginAsync<Options, Server> = async (fastify, _options) => {
   expectType<Server>(fastify.server)
 }
 
 expectType<FastifyPluginAsync<Options, Server>>(fastifyPlugin(pluginAsyncWithServer))
 
-const pluginAsyncWithTypeProvider: FastifyPluginAsync<Options, Server, TypeBoxTypeProvider> = async (fastify, options) => { }
+const pluginAsyncWithTypeProvider: FastifyPluginAsync<Options, Server, TypeBoxTypeProvider> = async (_fastify, _options) => { }
 
 expectType<FastifyPluginAsync<Options, Server, TypeBoxTypeProvider>>(fastifyPlugin(pluginAsyncWithTypeProvider))
 
@@ -123,8 +123,8 @@ fastifyPlugin<Options>(async function (fastify, options) {
   expectType<Options>(options)
 })
 
-expectAssignable<FastifyPluginAsync<Options, RawServerDefault, FastifyTypeProviderDefault, FastifyBaseLogger>>(fastifyPlugin(async function (fastify: FastifyInstance, options: Options) { }))
-expectNotType<any>(fastifyPlugin(async function (fastify: FastifyInstance, options: Options) { }))
+expectAssignable<FastifyPluginAsync<Options, RawServerDefault, FastifyTypeProviderDefault, FastifyBaseLogger>>(fastifyPlugin(async function (_fastify: FastifyInstance, _options: Options) { }))
+expectNotType<any>(fastifyPlugin(async function (_fastify: FastifyInstance, _options: Options) { }))
 
 fastifyPlugin(async function (fastify, options: Options) {
   expectType<FastifyInstance>(fastify)
@@ -137,13 +137,13 @@ fastifyPlugin(async function (fastify, options) {
 })
 
 expectError(
-  fastifyPlugin(async function (fastify, options: Options, next) {
+  fastifyPlugin(async function (fastify, options: Options, _next) {
     expectType<FastifyInstance>(fastify)
     expectType<Options>(options)
   })
 )
-expectAssignable<FastifyPluginCallback<Options>>(fastifyPlugin(function (fastify, options, next) { }))
-expectNotType<any>(fastifyPlugin(function (fastify, options, next) { }))
+expectAssignable<FastifyPluginCallback<Options>>(fastifyPlugin(function (_fastify, _options, _next) { }))
+expectNotType<any>(fastifyPlugin(function (_fastify, _options, _next) { }))
 
 fastifyPlugin(function (fastify, options: Options, next) {
   expectType<FastifyInstance>(fastify)
@@ -152,7 +152,7 @@ fastifyPlugin(function (fastify, options: Options, next) {
 })
 
 expectError(
-  fastifyPlugin(function (fastify, options: Options, next) {
+  fastifyPlugin(function (fastify, options: Options, _next) {
     expectType<FastifyInstance>(fastify)
     expectType<Options>(options)
     return Promise.resolve()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
