### PR TITLE
chore: removed interface deprecated

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,11 +26,6 @@ declare namespace fastifyPlugin {
     dependencies?: string[],
     encapsulate?: boolean
   }
-  // Exporting PluginOptions for backward compatibility after renaming it to PluginMetadata
-  /**
-   * @deprecated Use PluginMetadata instead
-   */
-  export interface PluginOptions extends PluginMetadata {}
 
   export const fastifyPlugin: FastifyPlugin
   export { fastifyPlugin as default }


### PR DESCRIPTION
Proposal:

- Removes the `PluginOptions` interface that was kept for backward compatibility after renaming it to `PluginMetadata`.

- `PluginOptions` has been marked as `@deprecated` for some time, this PR completes the cleanup by dropping it entirely.

Note:

- Release a major version of the plugin after this pull request has been merged
- PR reference:
   - https://github.com/fastify/fastify-swagger-ui/pull/274