### PR TITLE
docs: clarify TypeScript plugin styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ fp(pluginAsyncWithTypes)
 fp(async (fastify: FastifyInstance, options: FastifyPluginOptions): Promise<void> => { })
 ```
 
+Do not mix the callback and async styles in the same plugin. An async plugin
+must not accept or call the `done` callback, and a callback-style plugin must
+not be declared with `async`.
+
 ## Acknowledgments
 
 This project is kindly sponsored by:


### PR DESCRIPTION
## Summary

- Documents that TypeScript plugins should not mix callback and async styles.
- Calls out that async plugins should not accept/use `done`, while callback plugins should not be declared `async`.

Fixes fastify/fastify-plugin#221.

## Verification

- `npm test`
- `npm run lint`
- `git diff --check`

## Contribution notes

- AI-assisted: yes, Codex helped prepare this documentation change.
- Human reviewed: yes, I reviewed the final diff and test output before opening this PR.
- Duplicate check: issue Development references are empty; related PR search found only merged PR #218 and no open competing docs PR.
