### PR TITLE
fix(index): throw intended `TypeError` when the plugin is nullish

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ let count = 0
 function plugin (fn, options = {}) {
   let autoName = false
 
-  if (fn.default !== undefined) {
+  if (fn?.default !== undefined) {
     // Support for 'export default' behaviour in transpiled ECMAScript module
     fn = fn.default
   }

--- a/test/test.js
+++ b/test/test.js
@@ -49,6 +49,19 @@ test('should throw if the plugin is not a function', (t) => {
   }
 })
 
+test('should throw the type error if the plugin is nullish', (t) => {
+  t.plan(2)
+
+  t.assert.throws(() => fp(undefined), {
+    name: 'TypeError',
+    message: 'fastify-plugin expects a function, instead got a \'undefined\''
+  })
+  t.assert.throws(() => fp(null), {
+    name: 'TypeError',
+    message: 'fastify-plugin expects a function, instead got a \'object\''
+  })
+})
+
 test('should check the fastify version', (t) => {
   t.plan(1)
 


### PR DESCRIPTION
Throws an intentional `TypeError` when the plugin passed to the function is nullish rather than a confusing `"Cannot read properties of undefined (reading 'default')"`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
