### PR TITLE
fix(index): do not mutate options object

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function plugin (fn, options = {}) {
 
   if (!options.name) {
     autoName = true
-    options.name = getPluginName(fn) + '-auto-' + count++
+    options = { ...options, name: getPluginName(fn) + '-auto-' + count++ }
   }
 
   fn[Symbol.for('skip-override')] = options.encapsulate !== true

--- a/test/test.js
+++ b/test/test.js
@@ -122,7 +122,7 @@ test('should throw if the version number is not a string', (t) => {
 })
 
 test('Should accept an option object', (t) => {
-  t.plan(2)
+  t.plan(4)
 
   const opts = { hello: 'world' }
 
@@ -132,12 +132,15 @@ test('Should accept an option object', (t) => {
 
   fp(plugin, opts)
 
+  const meta = plugin[Symbol.for('plugin-meta')]
   t.assert.ok(plugin[Symbol.for('skip-override')], 'skip-override symbol should be present')
-  t.assert.deepStrictEqual(plugin[Symbol.for('plugin-meta')], opts, 'plugin-meta should match opts')
+  t.assert.strictEqual(meta.hello, 'world', 'plugin-meta should carry the options')
+  t.assert.match(meta.name, /^plugin-auto-\d+$/, 'plugin-meta should carry the generated name')
+  t.assert.deepStrictEqual(opts, { hello: 'world' }, 'options must not be mutated')
 })
 
 test('Should accept an option object and checks the version', (t) => {
-  t.plan(2)
+  t.plan(3)
 
   const opts = { hello: 'world', fastify: '>=0.10.0' }
 
@@ -146,8 +149,34 @@ test('Should accept an option object and checks the version', (t) => {
   }
 
   fp(plugin, opts)
+  const meta = plugin[Symbol.for('plugin-meta')]
   t.assert.ok(plugin[Symbol.for('skip-override')])
-  t.assert.deepStrictEqual(plugin[Symbol.for('plugin-meta')], opts)
+  t.assert.deepStrictEqual({ hello: meta.hello, fastify: meta.fastify }, opts)
+  t.assert.deepStrictEqual(opts, { hello: 'world', fastify: '>=0.10.0' }, 'options must not be mutated')
+})
+
+test('Should keep options by reference when a name is given', (t) => {
+  t.plan(1)
+
+  const opts = { name: 'by-reference', fastify: '>=0.10.0' }
+  const plugin = fp((_fastify, _opts, next) => next(), opts)
+
+  t.assert.strictEqual(plugin[Symbol.for('plugin-meta')], opts)
+})
+
+test('Should give distinct auto names to plugins that share one options object', (t) => {
+  t.plan(4)
+
+  const shared = { fastify: '>=0.10.0' }
+  const first = fp((_fastify, _opts, next) => next(), shared)
+  const second = fp((_fastify, _opts, next) => next(), shared)
+
+  const firstName = first[Symbol.for('plugin-meta')].name
+  const secondName = second[Symbol.for('plugin-meta')].name
+  t.assert.match(firstName, /^test-auto-\d+$/)
+  t.assert.match(secondName, /^test-auto-\d+$/)
+  t.assert.notStrictEqual(firstName, secondName, 'the second plugin must not inherit the first auto name')
+  t.assert.strictEqual(shared.name, undefined, 'options must not be mutated')
 })
 
 test('should set anonymous function name to file it was called from with a counter', (t) => {


### PR DESCRIPTION
Writing generated names back to the caller-supplied `options` object made anonymous plugins sharing said object reuse the first name.

This PR fixes that by shallow copying the `options` object when generating a name.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
