### PR TITLE
fix(index): type check `options.name`

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,10 @@ function plugin (fn, options = {}) {
     throw new TypeError(`fastify-plugin expects a version string, instead got '${typeof options.fastify}'`)
   }
 
+  if (options.name && typeof options.name !== 'string') {
+    throw new TypeError(`fastify-plugin expects a name string, instead got '${typeof options.name}'`)
+  }
+
   if (!options.name) {
     autoName = true
     options.name = getPluginName(fn) + '-auto-' + count++

--- a/test/test.js
+++ b/test/test.js
@@ -121,6 +121,36 @@ test('should throw if the version number is not a string', (t) => {
   }
 })
 
+test('should throw if the name is not a string', (t) => {
+  const cases = [
+    { name: 123, type: 'number' },
+    { name: true, type: 'boolean' },
+    { name: {}, type: 'object' },
+    { name: ['a-b'], type: 'object' },
+    { name: Symbol('a'), type: 'symbol' },
+    { name: () => {}, type: 'function' }
+  ]
+  t.plan(cases.length)
+
+  for (const { name, type } of cases) {
+    t.assert.throws(() => fp(() => { }, { name }), {
+      name: 'TypeError',
+      message: `fastify-plugin expects a name string, instead got '${type}'`
+    })
+  }
+})
+
+test('should auto-name the plugin if the name is an empty string', (t) => {
+  t.plan(2)
+
+  const fn = fp((_fastify, _opts, next) => next(), {
+    name: ''
+  })
+
+  t.assert.match(fn[Symbol.for('plugin-meta')].name, /^test-auto-\d+$/)
+  t.assert.match(fn[Symbol.for('fastify.display-name')], /^test-auto-\d+$/)
+})
+
 test('Should accept an option object', (t) => {
   t.plan(2)
 


### PR DESCRIPTION
`options.fastify` is type checked but `options.name` is not, so a truthy non-string name reaches `toCamelCase()` and throws a `"TypeError: name.replace is not a function"`.
This PR fixes that, so it now rejects with the same style of error used by `options.fastify`.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
