### PR TITLE
perf(index): hoist `Symbol.for` lookups to module-level

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@
 const getPluginName = require('./lib/getPluginName')
 const toCamelCase = require('./lib/toCamelCase')
 
+const kSkipOverride = Symbol.for('skip-override')
+const kDisplayName = Symbol.for('fastify.display-name')
+const kPluginMeta = Symbol.for('plugin-meta')
+
 let count = 0
 
 function plugin (fn, options = {}) {
@@ -42,9 +46,9 @@ function plugin (fn, options = {}) {
     options.name = getPluginName(fn) + '-auto-' + count++
   }
 
-  fn[Symbol.for('skip-override')] = options.encapsulate !== true
-  fn[Symbol.for('fastify.display-name')] = options.name
-  fn[Symbol.for('plugin-meta')] = options
+  fn[kSkipOverride] = options.encapsulate !== true
+  fn[kDisplayName] = options.name
+  fn[kPluginMeta] = options
 
   // Faux modules support
   if (!fn.default) {


### PR DESCRIPTION
Move the three `Symbol.for()` lookups to named constants at module load. This avoids repeated lookups and follows the pattern used in [avvio](https://github.com/fastify/avvio/blob/1a15d14fbf4c1dc0db6c952bb673f974d7237ac1/lib/symbols.js).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
