### PR TITLE
style(lib/getpluginname): use upper snakecase for regex consts

### DIFF
--- a/lib/getPluginName.js
+++ b/lib/getPluginName.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const fpStackTracePattern = /at\s(?:.*\.)?plugin\s.*\n\s*(.*)/
-const fileNamePattern = /(\w*(\.\w*)*)\..*/
+const FP_STACK_TRACE_REG = /at\s(?:.*\.)?plugin\s.*\n\s*(.*)/
+const FILE_NAME_REG = /(\w*(\.\w*)*)\..*/
 
 module.exports = function getPluginName (fn) {
   if (fn.name.length > 0) return fn.name
@@ -17,9 +17,9 @@ module.exports = function getPluginName (fn) {
 }
 
 function extractPluginName (stack) {
-  const m = stack.match(fpStackTracePattern)
+  const m = stack.match(FP_STACK_TRACE_REG)
 
   // get last section of path and match for filename
-  return m ? m[1].split(/[/\\]/).slice(-1)[0].match(fileNamePattern)[1] : 'anonymous'
+  return m ? m[1].split(/[/\\]/).slice(-1)[0].match(FILE_NAME_REG)[1] : 'anonymous'
 }
 module.exports.extractPluginName = extractPluginName


### PR DESCRIPTION
Uses same style used across rest of fastify repos.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
